### PR TITLE
Fix placeholder URL encoding

### DIFF
--- a/components/emoji-grid.tsx
+++ b/components/emoji-grid.tsx
@@ -59,7 +59,8 @@ export default function EmojiGrid() {
 
   // Function to get a placeholder image for an emoji
   const getPlaceholderImage = (emojiName: string) => {
-    return `/placeholder.svg?height=128&width=128&query=${emojiName}%20emoji`
+    // Encode the emoji name so special characters don't break the URL
+    return `/placeholder.svg?height=128&width=128&query=${encodeURIComponent(emojiName)}%20emoji`
   }
 
   // Handle image error


### PR DESCRIPTION
## Summary
- ensure emoji names with spaces/special characters generate a valid placeholder URL

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f3b1991d083239083c50cca933a1a