### PR TITLE
feat: improve pack browser filters and slack uploads

### DIFF
--- a/app/create/page.tsx
+++ b/app/create/page.tsx
@@ -16,7 +16,14 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Input } from "@/components/ui/input"
 import { Sheet, SheetContent } from "@/components/ui/sheet"
 import { Badge } from "@/components/ui/badge"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
 import { VideoFrameExtractor } from "@/lib/utils/video-frame-extractor"
 import { ChromeIcon } from "@/components/icons/chrome-icon"
 import { useToast } from "@/components/ui/use-toast"
@@ -95,6 +102,10 @@ function EmojiCreatorPage() {
     total: number
     stage: "uploading" | "complete"
   } | null>(null)
+  const [isRateLimitDialogOpen, setIsRateLimitDialogOpen] = useState(false)
+  const [pendingSlackUploadSource, setPendingSlackUploadSource] = useState<
+    "desktop" | "sheet" | null
+  >(null)
   const [showUploadOverlay, setShowUploadOverlay] = useState(false)
   const { toast } = useToast()
 
@@ -130,7 +141,7 @@ function EmojiCreatorPage() {
   }, [])
 
   // Pack browser state
-  const packBrowser = usePackBrowser(20, emojiData)
+  const packBrowser = usePackBrowser(Number.POSITIVE_INFINITY, emojiData)
 
   const updateCartOpen = useCallback(
     (open: boolean, source: 'toolbar' | 'sheet' | 'sheet-action') => {
@@ -144,6 +155,133 @@ function EmojiCreatorPage() {
       )
     },
     [packBrowser.selectedEmojis.length]
+  )
+
+  const handleRateLimitCancel = useCallback(() => {
+    setIsRateLimitDialogOpen(false)
+    setPendingSlackUploadSource(null)
+  }, [])
+
+  const performSlackUpload = useCallback(
+    async (_source: 'desktop' | 'sheet') => {
+      const selected = packBrowser.getSelectedEmojis()
+      if (selected.length === 0) return
+
+      const { uploadPackEmojiToSlack } = await import('@/lib/utils/slack-upload')
+
+      let successCount = 0
+      let failedCount = 0
+      const errors: string[] = []
+      const total = selected.length
+
+      setUploadProgress({ completed: 0, failed: 0, total, stage: 'uploading' })
+
+      const uploadToast = toast({
+        title: 'Uploading to Slack...',
+        description: `0/${total} (0%)`,
+        duration: Infinity,
+      })
+
+      const updateUploadToast = (message: string) => {
+        uploadToast.update({
+          id: uploadToast.id,
+          title: 'Uploading to Slack...',
+          description: message,
+          duration: Infinity,
+        })
+      }
+
+      for (let i = 0; i < selected.length; i++) {
+        const emoji = selected[i]
+        try {
+          const effectiveName = packBrowser.getEffectiveName(emoji)
+          const result = await uploadPackEmojiToSlack(
+            emoji.imageURL,
+            effectiveName,
+            emoji.isAnimated
+          )
+
+          if (result.success) {
+            successCount++
+          } else {
+            failedCount++
+            errors.push(`${effectiveName}: ${result.error || 'Unknown error'}`)
+          }
+        } catch (error) {
+          const effectiveName = packBrowser.getEffectiveName(emoji)
+          console.error(`Failed to upload ${effectiveName}:`, error)
+          failedCount++
+          errors.push(
+            `${effectiveName}: ${error instanceof Error ? error.message : 'Unknown error'}`
+          )
+        }
+
+        const completed = successCount + failedCount
+        const percentage = Math.round((completed / total) * 100)
+        setUploadProgress((prev) =>
+          prev ? { ...prev, completed, failed: failedCount } : prev
+        )
+        updateUploadToast(
+          `${completed}/${total} (${percentage}%) - ${successCount} succeeded${
+            failedCount > 0 ? `, ${failedCount} failed` : ''
+          }`
+        )
+      }
+
+      uploadToast.dismiss()
+      setUploadProgress((prev) => (prev ? { ...prev, stage: 'complete' } : prev))
+
+      if (successCount > 0) {
+        packBrowser.clearSelectionsAndStorage()
+        toast({
+          title: 'Upload complete',
+          description: `Successfully uploaded ${successCount} emoji${
+            successCount > 1 ? 's' : ''
+          } to Slack${failedCount > 0 ? `. ${failedCount} failed.` : ''}`,
+          duration: 8000,
+        })
+      }
+
+      if (failedCount > 0) {
+        console.error('Upload errors:', errors)
+        toast({
+          title: `${failedCount} upload${failedCount > 1 ? 's' : ''} failed`,
+          description: errors[0] || 'Unknown error',
+          variant: 'destructive',
+        })
+      }
+
+      if (successCount > 0) {
+        setTimeout(() => setUploadProgress(null), 3000)
+      } else {
+        setUploadProgress(null)
+      }
+    },
+    [packBrowser, toast]
+  )
+
+  const handleRateLimitConfirm = useCallback(async () => {
+    const source = pendingSlackUploadSource
+    handleRateLimitCancel()
+    if (source) {
+      await performSlackUpload(source)
+    }
+  }, [handleRateLimitCancel, pendingSlackUploadSource, performSlackUpload])
+
+  const requestSlackUpload = useCallback(
+    async (source: 'desktop' | 'sheet') => {
+      const selected = packBrowser.getSelectedEmojis()
+      if (selected.length === 0) return
+
+      if (selected.length > 20) {
+        setPendingSlackUploadSource(source)
+        setIsRateLimitDialogOpen(true)
+        return
+      }
+
+      await performSlackUpload(source)
+    },
+    [packBrowser, performSlackUpload]
   )
 
   useEffect(() => {
@@ -1169,7 +1307,7 @@ function EmojiCreatorPage() {
                 <div className="hidden xl:flex xl:flex-col xl:min-h-0 xl:h-full">
                   <PackSelectionSidebar
                     selectedEmojis={packBrowser.selectedEmojis}
-                    maxSelection={20}
+                    maxSelection={packBrowser.maxSelection}
                     nameStatuses={packBrowser.nameStatuses}
                     editingName={packBrowser.editingName}
                     editingValue={packBrowser.editingValue}
@@ -1312,94 +1450,7 @@ function EmojiCreatorPage() {
                       }
                     }}
                     onSendToSlack={async () => {
-                      const selected = packBrowser.getSelectedEmojis()
-                      if (selected.length === 0) return
-
-                      // Upload pack emojis directly to Slack without processing
-                      const { uploadPackEmojiToSlack } = await import('@/lib/utils/slack-upload')
-
-                      let successCount = 0
-                      let failedCount = 0
-                      const errors: string[] = []
-                      const total = selected.length
-
-                      setUploadProgress({ completed: 0, failed: 0, total, stage: "uploading" })
-
-                      const uploadToast = toast({
-                        title: "Uploading to Slack...",
-                        description: `0/${total} (0%)`,
-                        duration: Infinity,
-                      })
-
-                      const updateUploadToast = (message: string) => {
-                        uploadToast.update({
-                          id: uploadToast.id,
-                          title: "Uploading to Slack...",
-                          description: message,
-                          duration: Infinity,
-                        })
-                      }
-
-                      for (let i = 0; i < selected.length; i++) {
-                        const emoji = selected[i]
-                        try {
-                          // Use custom name if available
-                          const effectiveName = packBrowser.getEffectiveName(emoji)
-                          const result = await uploadPackEmojiToSlack(
-                            emoji.imageURL,
-                            effectiveName,
-                            emoji.isAnimated
-                          )
-
-                          if (result.success) {
-                            successCount++
-                          } else {
-                            failedCount++
-                            errors.push(`${effectiveName}: ${result.error || 'Unknown error'}`)
-                          }
-
-                          // Update progress - show completed count and percentage
-                          const completed = successCount + failedCount
-                          const percentage = Math.round((completed / total) * 100)
-                          setUploadProgress((prev) =>
-                            prev ? { ...prev, completed, failed: failedCount } : prev
-                          )
-                          updateUploadToast(`${completed}/${total} (${percentage}%) - ${successCount} succeeded${failedCount > 0 ? `, ${failedCount} failed` : ''}`)
-                        } catch (error) {
-                          const effectiveName = packBrowser.getEffectiveName(emoji)
-                          console.error(`Failed to upload ${effectiveName}:`, error)
-                          failedCount++
-                          errors.push(`${effectiveName}: ${error instanceof Error ? error.message : 'Unknown error'}`)
-                        }
-                      }
-
-                      uploadToast.dismiss()
-                      setUploadProgress((prev) => (prev ? { ...prev, stage: "complete" } : prev))
-
-                      // Show final result
-                      if (successCount > 0) {
-                        packBrowser.clearSelectionsAndStorage()
-                        toast({
-                          title: "Upload complete",
-                          description: `Successfully uploaded ${successCount} emoji${successCount > 1 ? 's' : ''} to Slack${failedCount > 0 ? `. ${failedCount} failed.` : ''}`,
-                          duration: 8000,
-                        })
-                      }
-
-                      if (failedCount > 0) {
-                        console.error('Upload errors:', errors)
-                        toast({
-                          title: `${failedCount} upload${failedCount > 1 ? 's' : ''} failed`,
-                          description: errors[0] || 'Unknown error',
-                          variant: "destructive",
-                        })
-                      }
-
-                      if (successCount > 0) {
-                        setTimeout(() => setUploadProgress(null), 3000)
-                      } else {
-                        setUploadProgress(null)
-                      }
+                      await requestSlackUpload('desktop')
                     }}
                   />
                 </div>
@@ -1408,37 +1459,37 @@ function EmojiCreatorPage() {
                 <Sheet open={isCartOpen} onOpenChange={(open) => updateCartOpen(open, 'sheet')}>
                   <SheetContent side="right" className="w-full sm:max-w-md p-0">
                     <PackSelectionSidebar
-                        selectedEmojis={packBrowser.selectedEmojis}
-                        maxSelection={20}
-                        nameStatuses={packBrowser.nameStatuses}
-                        editingName={packBrowser.editingName}
-                        editingValue={packBrowser.editingValue}
-                        onSetEditingName={packBrowser.setEditingName}
-                        onSetEditingValue={packBrowser.setEditingValue}
-                        onSaveCustomName={packBrowser.saveCustomName}
-                        customNames={packBrowser.customNames}
-                        onRemove={(emoji) => {
-                          const remainingCount = Math.max(packBrowser.selectedEmojis.length - 1, 0)
-                          packBrowser.removeFromSelection(emoji)
-                          openpanel.track('Emoji Creator: Selection Item Removed', {
-                            id: emoji.id,
-                            name: emoji.name,
-                            remainingCount,
-                          })
-                        }}
-                        onClear={() => {
-                          const previousCount = packBrowser.selectedEmojis.length
-                          setDownloadProgress(null)
-                          setUploadProgress(null)
-                          packBrowser.clearSelection()
-                          openpanel.track('Emoji Creator: Selection Cleared', {
-                            previousCount,
-                          })
-                        }}
-                        hasSlackConnection={hasSlack}
-                        downloadProgress={downloadProgress}
-                        uploadProgress={uploadProgress}
-                        onDownload={async () => {
+                      selectedEmojis={packBrowser.selectedEmojis}
+                      maxSelection={packBrowser.maxSelection}
+                      nameStatuses={packBrowser.nameStatuses}
+                      editingName={packBrowser.editingName}
+                      editingValue={packBrowser.editingValue}
+                      onSetEditingName={packBrowser.setEditingName}
+                      onSetEditingValue={packBrowser.setEditingValue}
+                      onSaveCustomName={packBrowser.saveCustomName}
+                      customNames={packBrowser.customNames}
+                      onRemove={(emoji) => {
+                        const remainingCount = Math.max(packBrowser.selectedEmojis.length - 1, 0)
+                        packBrowser.removeFromSelection(emoji)
+                        openpanel.track('Emoji Creator: Selection Item Removed', {
+                          id: emoji.id,
+                          name: emoji.name,
+                          remainingCount,
+                        })
+                      }}
+                      onClear={() => {
+                        const previousCount = packBrowser.selectedEmojis.length
+                        setDownloadProgress(null)
+                        setUploadProgress(null)
+                        packBrowser.clearSelection()
+                        openpanel.track('Emoji Creator: Selection Cleared', {
+                          previousCount,
+                        })
+                      }}
+                      hasSlackConnection={hasSlack}
+                      downloadProgress={downloadProgress}
+                      uploadProgress={uploadProgress}
+                      onDownload={async () => {
                           updateCartOpen(false, 'sheet-action')
                           // Reuse the same download logic
                           const selected = packBrowser.getSelectedEmojis()
@@ -1543,92 +1594,7 @@ function EmojiCreatorPage() {
                           }
                         }}
                         onSendToSlack={async () => {
-                          updateCartOpen(false, 'sheet-action')
-                          // Reuse the same upload logic
-                          const selected = packBrowser.getSelectedEmojis()
-                          if (selected.length === 0) return
-
-                          const { uploadPackEmojiToSlack } = await import('@/lib/utils/slack-upload')
-
-                          let successCount = 0
-                          let failedCount = 0
-                          const errors: string[] = []
-                          const total = selected.length
-
-                          setUploadProgress({ completed: 0, failed: 0, total, stage: "uploading" })
-
-                          const uploadToast = toast({
-                            title: "Uploading to Slack...",
-                            description: `0/${total} (0%)`,
-                            duration: Infinity,
-                          })
-
-                          const updateUploadToast = (message: string) => {
-                            uploadToast.update({
-                              id: uploadToast.id,
-                              title: "Uploading to Slack...",
-                              description: message,
-                              duration: Infinity,
-                            })
-                          }
-
-                          for (let i = 0; i < selected.length; i++) {
-                            const emoji = selected[i]
-                            try {
-                              const effectiveName = packBrowser.getEffectiveName(emoji)
-                              const result = await uploadPackEmojiToSlack(
-                                emoji.imageURL,
-                                effectiveName,
-                                emoji.isAnimated
-                              )
-
-                              if (result.success) {
-                                successCount++
-                              } else {
-                                failedCount++
-                                errors.push(`${effectiveName}: ${result.error || 'Unknown error'}`)
-                              }
-
-                              const completed = successCount + failedCount
-                              const percentage = Math.round((completed / total) * 100)
-                              setUploadProgress((prev) =>
-                                prev ? { ...prev, completed, failed: failedCount } : prev
-                              )
-                              updateUploadToast(`${completed}/${total} (${percentage}%) - ${successCount} succeeded${failedCount > 0 ? `, ${failedCount} failed` : ''}`)
-                            } catch (error) {
-                              const effectiveName = packBrowser.getEffectiveName(emoji)
-                              console.error(`Failed to upload ${effectiveName}:`, error)
-                              failedCount++
-                              errors.push(`${effectiveName}: ${error instanceof Error ? error.message : 'Unknown error'}`)
-                            }
-                          }
-
-                          uploadToast.dismiss()
-                          setUploadProgress((prev) => (prev ? { ...prev, stage: "complete" } : prev))
-
-                          if (successCount > 0) {
-                            packBrowser.clearSelectionsAndStorage()
-                            toast({
-                              title: "Upload complete",
-                              description: `Successfully uploaded ${successCount} emoji${successCount > 1 ? 's' : ''} to Slack${failedCount > 0 ? `. ${failedCount} failed.` : ''}`,
-                              duration: 8000,
-                            })
-                          }
-
-                          if (failedCount > 0) {
-                            console.error('Upload errors:', errors)
-                            toast({
-                              title: `${failedCount} upload${failedCount > 1 ? 's' : ''} failed`,
-                              description: errors[0] || 'Unknown error',
-                              variant: "destructive",
-                            })
-                          }
-
-                          if (successCount > 0) {
-                            setTimeout(() => setUploadProgress(null), 3000)
-                          } else {
-                            setUploadProgress(null)
-                          }
+                          await requestSlackUpload('sheet')
                         }}
                     />
                   </SheetContent>
@@ -1798,6 +1764,35 @@ function EmojiCreatorPage() {
           onExport={handleGifExport}
         />
       )}
+
+      <Dialog
+        open={isRateLimitDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            handleRateLimitCancel()
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Large upload warning</DialogTitle>
+            <DialogDescription>
+              Uploading more than 20 emojis per minute may cause Slack to temporarily rate limit your workspace. Do you want to
+              continue?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 sm:gap-3">
+            <Button variant="outline" onClick={handleRateLimitCancel}>
+              Cancel
+            </Button>
+            <Button onClick={() => {
+              void handleRateLimitConfirm()
+            }}>
+              Continue upload
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {/* Upload Overlay Dialog */}
       <Dialog open={showUploadOverlay} onOpenChange={setShowUploadOverlay}>

--- a/components/pack-browser.tsx
+++ b/components/pack-browser.tsx
@@ -14,7 +14,7 @@ import type { Variants } from "framer-motion"
 import { Search, Grid3x3, List, Loader2, Download, X, CheckCircle2, AlertCircle, Edit2, Send, TrendingUp, Clock, Laugh, Cat, Bird, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { ScrollArea } from "@/components/ui/scroll-area"
+import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card"
 import { toast } from "sonner"
 import { packDiscovery } from "@/lib/services/pack-discovery"
@@ -84,7 +84,11 @@ const listItemVariants: Variants = {
 }
 
 // Custom hook for pack browser state management
-export function usePackBrowser(maxSelection: number = 20, existingEmojis: any[] = []) {
+export function usePackBrowser(
+  maxSelection: number = Number.POSITIVE_INFINITY,
+  existingEmojis: any[] = []
+) {
+  const selectionLimit = Number.isFinite(maxSelection) ? maxSelection : null
   const [selectedTab, setSelectedTab] = useState<Tab>("popular")
   const [searchQuery, setSearchQuery] = useState("")
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid")
@@ -317,8 +321,8 @@ export function usePackBrowser(maxSelection: number = 20, existingEmojis: any[] 
       if (next.has(key)) {
         next.delete(key)
       } else {
-        if (next.size >= maxSelection) {
-          toast.error(`Maximum ${maxSelection} emojis per selection`)
+        if (selectionLimit !== null && next.size >= selectionLimit) {
+          toast.error(`Maximum ${selectionLimit} emojis per selection`)
           return prev
         }
         next.add(key)
@@ -413,6 +417,8 @@ export function usePackBrowser(maxSelection: number = 20, existingEmojis: any[] 
     getEffectiveName,
     clearSelectionsAndStorage,
 
+    maxSelection: selectionLimit,
+
     // Computed
     selectedEmojis: getSelectedEmojis(),
 
@@ -436,8 +442,8 @@ export function PackBrowserTabs({ selectedTab, onSelectTab, searchQuery }: PackB
   if (searchQuery) return null
 
   return (
-    <ScrollArea className="w-full whitespace-nowrap">
-      <div className="flex gap-2 pb-2">
+    <ScrollArea type="scroll" className="w-full">
+      <div className="flex min-w-max gap-2 pb-2 pr-4 whitespace-nowrap">
         <Button
           variant={selectedTab === "popular" ? "default" : "secondary"}
           size="sm"
@@ -493,6 +499,7 @@ export function PackBrowserTabs({ selectedTab, onSelectTab, searchQuery }: PackB
           Bufo
         </Button>
       </div>
+      <ScrollBar orientation="horizontal" className="mt-1" />
     </ScrollArea>
   )
 }
@@ -648,7 +655,7 @@ export function PackEmojiGrid({ emojis, loading, viewMode, selectedIds, onToggle
 
 interface PackSelectionSidebarProps {
   selectedEmojis: PackEmoji[]
-  maxSelection: number
+  maxSelection?: number | null
   nameStatuses: Map<string, NameStatus>
   editingName: string | null
   editingValue: string
@@ -694,6 +701,8 @@ export function PackSelectionSidebar({
   uploadProgress,
   isDemoMode = false,
 }: PackSelectionSidebarProps) {
+  const selectionLimit =
+    typeof maxSelection === "number" && Number.isFinite(maxSelection) ? maxSelection : null
   const hasNameChecking = nameStatuses.size > 0
   const takenCount = Array.from(nameStatuses.values()).filter((s) => s === "taken").length
   const checkingCount = Array.from(nameStatuses.values()).filter((s) => s === "checking").length
@@ -718,9 +727,11 @@ export function PackSelectionSidebar({
             </Button>
           )}
         </div>
-        <p className="text-xs text-muted-foreground">
-          {selectedEmojis.length}/{maxSelection} selected
-        </p>
+          <p className="text-xs text-muted-foreground">
+            {selectionLimit !== null
+              ? `${selectedEmojis.length}/${selectionLimit} selected`
+              : `${selectedEmojis.length} selected`}
+          </p>
       </div>
 
       <ScrollArea className="flex-1 min-h-0 p-4">
@@ -919,9 +930,9 @@ export function PackSelectionSidebar({
             {takenCount} name{takenCount > 1 ? "s" : ""} taken - edit to continue
           </p>
         )}
-        {!isDemoMode && selectedEmojis.length > maxSelection && (
+        {!isDemoMode && selectionLimit !== null && selectedEmojis.length > selectionLimit && (
           <p className="text-xs text-destructive text-center">
-            Please select max {maxSelection} emojis
+            Please select max {selectionLimit} emojis
           </p>
         )}
       </div>


### PR DESCRIPTION
## Summary
- make the pack browser filters horizontally scrollable and drop the hard 20 emoji cap messaging
- reuse shared Slack upload logic so unlimited selections stay open on mobile and desktop while progress is shown
- warn users with a confirmation dialog before uploading more than 20 emojis to Slack to avoid rate limiting surprises

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e06abad1608323a1685cb6d31adb78