### PR TITLE
feat: Usage page — rename, UI polish, charts & info modal

### DIFF
--- a/__tests__/lib/services/reaction-service.test.ts
+++ b/__tests__/lib/services/reaction-service.test.ts
@@ -1,0 +1,105 @@
+import {
+  aggregateReactions,
+  getTopReactions,
+  getTrendingReactions,
+  getUserReactionStats,
+  getChannelBreakdown,
+  type ReactionEvent,
+  type AggregatedReaction,
+} from '@/lib/services/reaction-service'
+
+const now = Math.floor(Date.now() / 1000)
+const DAY = 86400
+
+const createEvent = (overrides: Partial<ReactionEvent> = {}): ReactionEvent => ({
+  emoji_name: 'thumbsup',
+  count: 1,
+  user_ids: ['U001'],
+  channel_id: 'C001',
+  timestamp: now - DAY,
+  ...overrides,
+})
+
+describe('aggregateReactions', () => {
+  it('should combine counts for the same emoji across events', () => {
+    const events: ReactionEvent[] = [
+      createEvent({ emoji_name: 'fire', count: 3 }),
+      createEvent({ emoji_name: 'fire', count: 5 }),
+      createEvent({ emoji_name: 'heart', count: 2 }),
+    ]
+    const result = aggregateReactions(events)
+    const fire = result.find(r => r.emoji_name === 'fire')
+    expect(fire).toBeDefined()
+    expect(fire!.total_count).toBe(8)
+    expect(result).toHaveLength(2)
+  })
+
+  it('should deduplicate user_ids across events', () => {
+    const events: ReactionEvent[] = [
+      createEvent({ emoji_name: 'fire', user_ids: ['U001', 'U002'] }),
+      createEvent({ emoji_name: 'fire', user_ids: ['U002', 'U003'] }),
+    ]
+    const result = aggregateReactions(events)
+    const fire = result.find(r => r.emoji_name === 'fire')
+    expect(fire!.unique_users).toBe(3)
+  })
+
+  it('should return empty array for empty input', () => {
+    expect(aggregateReactions([])).toEqual([])
+  })
+})
+
+describe('getTopReactions', () => {
+  it('should return reactions sorted by total_count descending', () => {
+    const aggregated: AggregatedReaction[] = [
+      { emoji_name: 'a', total_count: 5, unique_users: 2, events: [] },
+      { emoji_name: 'b', total_count: 20, unique_users: 5, events: [] },
+      { emoji_name: 'c', total_count: 10, unique_users: 3, events: [] },
+    ]
+    const top = getTopReactions(aggregated, 2)
+    expect(top).toHaveLength(2)
+    expect(top[0].emoji_name).toBe('b')
+    expect(top[1].emoji_name).toBe('c')
+  })
+})
+
+describe('getTrendingReactions', () => {
+  it('should identify emojis with increased usage in recent period', () => {
+    const events: ReactionEvent[] = [
+      createEvent({ emoji_name: 'fire', count: 1, timestamp: now - 10 * DAY }),
+      createEvent({ emoji_name: 'fire', count: 1, timestamp: now - 12 * DAY }),
+      createEvent({ emoji_name: 'fire', count: 4, timestamp: now - 2 * DAY }),
+      createEvent({ emoji_name: 'fire', count: 4, timestamp: now - 1 * DAY }),
+    ]
+    const trending = getTrendingReactions(events, 7 * DAY)
+    expect(trending.length).toBeGreaterThanOrEqual(1)
+    expect(trending[0].emoji_name).toBe('fire')
+    expect(trending[0].change_percent).toBeGreaterThan(0)
+  })
+})
+
+describe('getUserReactionStats', () => {
+  it('should aggregate reactions per user', () => {
+    const events: ReactionEvent[] = [
+      createEvent({ user_ids: ['U001', 'U002'], count: 2 }),
+      createEvent({ user_ids: ['U001'], count: 1 }),
+    ]
+    const stats = getUserReactionStats(events)
+    const u1 = stats.find(s => s.user_id === 'U001')
+    expect(u1!.reaction_count).toBe(2)
+  })
+})
+
+describe('getChannelBreakdown', () => {
+  it('should group top reactions by channel', () => {
+    const events: ReactionEvent[] = [
+      createEvent({ channel_id: 'C001', emoji_name: 'fire', count: 10 }),
+      createEvent({ channel_id: 'C001', emoji_name: 'heart', count: 5 }),
+      createEvent({ channel_id: 'C002', emoji_name: 'thumbsup', count: 20 }),
+    ]
+    const breakdown = getChannelBreakdown(events, 5)
+    expect(breakdown).toHaveLength(2)
+    const c1 = breakdown.find(b => b.channel_id === 'C001')
+    expect(c1!.top_reactions[0].emoji_name).toBe('fire')
+  })
+})

--- a/app/api/slack-reactions/route.ts
+++ b/app/api/slack-reactions/route.ts
@@ -1,0 +1,129 @@
+// app/api/slack-reactions/route.ts
+import { type NextRequest, NextResponse } from "next/server"
+import { validateProxyUrl, sanitizeErrorResponse } from "@/lib/utils/url-validation"
+import { applyRateLimit } from "@/lib/utils/api-security"
+
+interface SlackCurlRequest {
+  url: string
+  method?: string
+  headers?: Record<string, string>
+  formData?: Record<string, string>
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const rateLimitResponse = await applyRateLimit(request)
+    if (rateLimitResponse) return rateLimitResponse
+
+    const body = await request.json()
+    const curlRequest: SlackCurlRequest = body.curlRequest
+
+    if (!curlRequest?.url) {
+      return NextResponse.json({ error: "Invalid request: missing URL" }, { status: 400 })
+    }
+
+    const validation = validateProxyUrl(curlRequest.url)
+    if (!validation.valid) {
+      return NextResponse.json({ error: validation.error }, { status: 400 })
+    }
+
+    // Only allow conversations endpoints
+    const isConversationsEndpoint =
+      curlRequest.url.includes("/conversations.list") ||
+      curlRequest.url.includes("/conversations.view") ||
+      curlRequest.url.includes("/conversations.history")
+
+    if (!isConversationsEndpoint) {
+      return NextResponse.json(
+        { error: "Only conversations.list, conversations.view, and conversations.history endpoints are supported" },
+        { status: 400 }
+      )
+    }
+
+    // Ensure _x_id is in the URL
+    if (!curlRequest.url.includes("_x_id=")) {
+      const timestamp = Math.floor(Date.now() / 1000)
+      const randomHex = Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, "0")
+      const xId = `${randomHex}-${timestamp}.${Math.floor(Math.random() * 1000)}`
+      const separator = curlRequest.url.includes("?") ? "&" : "?"
+      curlRequest.url = `${curlRequest.url}${separator}_x_id=${xId}`
+    }
+
+    // Build fetch options
+    const headers: Record<string, string> = {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...(curlRequest.headers || {}),
+    }
+
+    const params = new URLSearchParams()
+    if (curlRequest.formData) {
+      for (const [key, value] of Object.entries(curlRequest.formData)) {
+        params.append(key, value)
+      }
+    }
+
+    const slackRes = await fetch(curlRequest.url, {
+      method: "POST",
+      headers,
+      body: params.toString(),
+    })
+
+    const slackData = await slackRes.json()
+
+    if (!slackData.ok) {
+      return NextResponse.json(
+        { error: slackData.error || "Slack API error", ok: false },
+        { status: 200 }
+      )
+    }
+
+    // For conversations.list, return channel list as-is (no message content)
+    if (curlRequest.url.includes("/conversations.list")) {
+      const channels = (slackData.channels || []).map((ch: any) => ({
+        id: ch.id,
+        name: ch.name,
+        is_private: ch.is_private || false,
+        num_members: ch.num_members || 0,
+      }))
+      return NextResponse.json({
+        ok: true,
+        channels,
+        response_metadata: slackData.response_metadata,
+      })
+    }
+
+    // For conversations.view / conversations.history:
+    // STRIP ALL MESSAGE CONTENT. Return ONLY reactions + timestamp.
+    const messages = slackData.messages || []
+    const reactions: Array<{
+      emoji_name: string
+      count: number
+      users: string[]
+      timestamp: number
+    }> = []
+
+    for (const msg of messages) {
+      if (!msg.reactions || !Array.isArray(msg.reactions)) continue
+      const msgTs = parseFloat(msg.ts) || 0
+      for (const reaction of msg.reactions) {
+        reactions.push({
+          emoji_name: reaction.name,
+          count: reaction.count || reaction.users?.length || 0,
+          users: reaction.users || [],
+          timestamp: Math.floor(msgTs),
+        })
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      reactions,
+      has_more: slackData.has_more || false,
+      response_metadata: slackData.response_metadata,
+    })
+  } catch (err: unknown) {
+    console.error("Slack reactions proxy error:", err)
+    const sanitized = sanitizeErrorResponse(err, "Reactions proxy request failed")
+    return NextResponse.json({ error: sanitized.message }, { status: 500 })
+  }
+}

--- a/app/api/slack-reactions/route.ts
+++ b/app/api/slack-reactions/route.ts
@@ -30,12 +30,11 @@ export async function POST(request: NextRequest) {
     // Only allow conversations endpoints
     const isConversationsEndpoint =
       curlRequest.url.includes("/conversations.list") ||
-      curlRequest.url.includes("/conversations.view") ||
       curlRequest.url.includes("/conversations.history")
 
     if (!isConversationsEndpoint) {
       return NextResponse.json(
-        { error: "Only conversations.list, conversations.view, and conversations.history endpoints are supported" },
+        { error: "Only conversations.list and conversations.history endpoints are supported" },
         { status: 400 }
       )
     }
@@ -88,11 +87,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({
         ok: true,
         channels,
-        response_metadata: slackData.response_metadata,
+        response_metadata: slackData.response_metadata?.next_cursor
+          ? { next_cursor: slackData.response_metadata.next_cursor }
+          : undefined,
       })
     }
 
-    // For conversations.view / conversations.history:
+    // For conversations.history:
     // STRIP ALL MESSAGE CONTENT. Return ONLY reactions + timestamp.
     const messages = slackData.messages || []
     const reactions: Array<{
@@ -119,7 +120,9 @@ export async function POST(request: NextRequest) {
       ok: true,
       reactions,
       has_more: slackData.has_more || false,
-      response_metadata: slackData.response_metadata,
+      response_metadata: slackData.response_metadata?.next_cursor
+        ? { next_cursor: slackData.response_metadata.next_cursor }
+        : undefined,
     })
   } catch (err: unknown) {
     console.error("Slack reactions proxy error:", err)

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -37,11 +37,7 @@ function EmojiDisplay({
       />
     )
   }
-  return (
-    <span className="text-base leading-none" title={`:${name}:`}>
-      {name}
-    </span>
-  )
+  return null
 }
 
 function ChannelRow({

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -8,6 +8,12 @@ import {
 } from "@/components/ui/collapsible"
 import { Badge } from "@/components/ui/badge"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { Hash, Lock, ChevronDown, ChevronRight } from "lucide-react"
 import type { ChannelReactionBreakdown } from "@/lib/services/reaction-service"
 import type { SlackChannel } from "@/app/reactions/hooks/use-reactions-state"
@@ -75,27 +81,34 @@ function ChannelRow({
 
       <CollapsibleContent>
         <div className="px-3 pb-3 pt-1">
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-            {item.top_reactions.map((reaction) => (
-              <div
-                key={reaction.emoji_name}
-                className="flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5"
-              >
-                <EmojiDisplay
-                  name={reaction.emoji_name}
-                  customEmojiUrls={customEmojiUrls}
-                />
-                <div className="min-w-0">
-                  <p className="text-xs font-medium truncate">
-                    :{reaction.emoji_name}:
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    {reaction.total_count.toLocaleString()}
-                  </p>
-                </div>
-              </div>
-            ))}
-          </div>
+          <TooltipProvider delayDuration={200}>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+              {item.top_reactions.map((reaction) => (
+                <Tooltip key={reaction.emoji_name}>
+                  <TooltipTrigger asChild>
+                    <div className="flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5 cursor-default">
+                      <EmojiDisplay
+                        name={reaction.emoji_name}
+                        customEmojiUrls={customEmojiUrls}
+                      />
+                      <div className="min-w-0">
+                        <p className="text-xs font-medium truncate">
+                          :{reaction.emoji_name}:
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {reaction.total_count.toLocaleString()}
+                        </p>
+                      </div>
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    <p className="font-medium">:{reaction.emoji_name}:</p>
+                    <p className="text-xs text-muted-foreground">{reaction.total_count.toLocaleString()} reactions</p>
+                  </TooltipContent>
+                </Tooltip>
+              ))}
+            </div>
+          </TooltipProvider>
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { useState } from "react"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { Badge } from "@/components/ui/badge"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Hash, Lock, ChevronDown, ChevronRight } from "lucide-react"
+import type { ChannelReactionBreakdown } from "@/lib/services/reaction-service"
+import type { SlackChannel } from "@/app/reactions/hooks/use-reactions-state"
+
+interface ChannelBreakdownProps {
+  breakdown: ChannelReactionBreakdown[]
+  channels: SlackChannel[]
+  customEmojiUrls: Map<string, string>
+}
+
+function EmojiDisplay({
+  name,
+  customEmojiUrls,
+}: {
+  name: string
+  customEmojiUrls: Map<string, string>
+}) {
+  const url = customEmojiUrls.get(name)
+  if (url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={url}
+        alt={`:${name}:`}
+        className="w-5 h-5 object-contain"
+        title={`:${name}:`}
+      />
+    )
+  }
+  return (
+    <span className="text-base leading-none" title={`:${name}:`}>
+      {name}
+    </span>
+  )
+}
+
+function ChannelRow({
+  item,
+  channel,
+  customEmojiUrls,
+}: {
+  item: ChannelReactionBreakdown
+  channel: SlackChannel | undefined
+  customEmojiUrls: Map<string, string>
+}) {
+  const [open, setOpen] = useState(false)
+
+  const displayName = channel?.name ?? item.channel_id
+  const isPrivate = channel?.is_private ?? false
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm hover:bg-muted/50 transition-colors text-left group">
+        {open ? (
+          <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0 transition-transform" />
+        ) : (
+          <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0 transition-transform" />
+        )}
+        {isPrivate ? (
+          <Lock className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        ) : (
+          <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        )}
+        <span className="flex-1 font-medium truncate">{displayName}</span>
+        <Badge variant="secondary" className="shrink-0 text-xs">
+          {item.total_count.toLocaleString()} reactions
+        </Badge>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent>
+        <div className="px-3 pb-3 pt-1">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+            {item.top_reactions.map((reaction) => (
+              <div
+                key={reaction.emoji_name}
+                className="flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5"
+              >
+                <EmojiDisplay
+                  name={reaction.emoji_name}
+                  customEmojiUrls={customEmojiUrls}
+                />
+                <div className="min-w-0">
+                  <p className="text-xs font-medium truncate">
+                    :{reaction.emoji_name}:
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {reaction.total_count.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
+export function ChannelBreakdown({
+  breakdown,
+  channels,
+  customEmojiUrls,
+}: ChannelBreakdownProps) {
+  if (breakdown.length === 0) return null
+
+  const channelMap = new Map(channels.map((c) => [c.id, c]))
+
+  const sorted = [...breakdown].sort((a, b) => b.total_count - a.total_count)
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">By Channel</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 p-3">
+        {sorted.map((item) => (
+          <ChannelRow
+            key={item.channel_id}
+            item={item}
+            channel={channelMap.get(item.channel_id)}
+            customEmojiUrls={customEmojiUrls}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -22,6 +22,7 @@ interface ChannelBreakdownProps {
   breakdown: ChannelReactionBreakdown[]
   channels: SlackChannel[]
   customEmojiUrls: Map<string, string>
+  onEmojiClick?: (name: string) => void
 }
 
 function EmojiDisplay({
@@ -50,10 +51,12 @@ function ChannelRow({
   item,
   channel,
   customEmojiUrls,
+  onEmojiClick,
 }: {
   item: ChannelReactionBreakdown
   channel: SlackChannel | undefined
   customEmojiUrls: Map<string, string>
+  onEmojiClick?: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
 
@@ -86,7 +89,10 @@ function ChannelRow({
               {item.top_reactions.map((reaction) => (
                 <Tooltip key={reaction.emoji_name}>
                   <TooltipTrigger asChild>
-                    <div className="flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5 cursor-default">
+                    <div
+                      className={`flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5 ${onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? "cursor-pointer hover:bg-muted/60" : "cursor-default"}`}
+                      onClick={onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? () => onEmojiClick(reaction.emoji_name) : undefined}
+                    >
                       <EmojiDisplay
                         name={reaction.emoji_name}
                         customEmojiUrls={customEmojiUrls}
@@ -119,6 +125,7 @@ export function ChannelBreakdown({
   breakdown,
   channels,
   customEmojiUrls,
+  onEmojiClick,
 }: ChannelBreakdownProps) {
   const channelMap = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels])
   const sorted = useMemo(() => [...breakdown].sort((a, b) => b.total_count - a.total_count), [breakdown])
@@ -137,6 +144,7 @@ export function ChannelBreakdown({
             item={item}
             channel={channelMap.get(item.channel_id)}
             customEmojiUrls={customEmojiUrls}
+            onEmojiClick={onEmojiClick}
           />
         ))}
       </CardContent>

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, useMemo } from "react"
 import {
   Collapsible,
   CollapsibleContent,
@@ -107,11 +107,10 @@ export function ChannelBreakdown({
   channels,
   customEmojiUrls,
 }: ChannelBreakdownProps) {
+  const channelMap = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels])
+  const sorted = useMemo(() => [...breakdown].sort((a, b) => b.total_count - a.total_count), [breakdown])
+
   if (breakdown.length === 0) return null
-
-  const channelMap = new Map(channels.map((c) => [c.id, c]))
-
-  const sorted = [...breakdown].sort((a, b) => b.total_count - a.total_count)
 
   return (
     <Card>

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -17,11 +17,13 @@ import {
 import { Hash, Lock, ChevronDown, ChevronRight } from "lucide-react"
 import type { ChannelReactionBreakdown } from "@/lib/services/reaction-service"
 import type { SlackChannel } from "@/app/reactions/hooks/use-reactions-state"
+import type { Emoji } from "@/lib/services/emoji-service"
 
 interface ChannelBreakdownProps {
   breakdown: ChannelReactionBreakdown[]
   channels: SlackChannel[]
   customEmojiUrls: Map<string, string>
+  emojiData: Emoji[]
   onEmojiClick?: (name: string) => void
 }
 
@@ -51,17 +53,22 @@ function ChannelRow({
   item,
   channel,
   customEmojiUrls,
+  userNameMap,
   onEmojiClick,
 }: {
   item: ChannelReactionBreakdown
   channel: SlackChannel | undefined
   customEmojiUrls: Map<string, string>
+  userNameMap: Map<string, string>
   onEmojiClick?: (name: string) => void
 }) {
   const [open, setOpen] = useState(false)
 
   const displayName = channel?.name ?? item.channel_id
   const isPrivate = channel?.is_private ?? false
+
+  // Filter to named reactors only
+  const namedReactors = item.top_reactors.filter((r) => userNameMap.has(r.user_id))
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
@@ -83,38 +90,60 @@ function ChannelRow({
       </CollapsibleTrigger>
 
       <CollapsibleContent>
-        <div className="px-3 pb-3 pt-1">
-          <TooltipProvider delayDuration={200}>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
-              {item.top_reactions.map((reaction) => (
-                <Tooltip key={reaction.emoji_name}>
-                  <TooltipTrigger asChild>
-                    <div
-                      className={`flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5 ${onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? "cursor-pointer hover:bg-muted/60" : "cursor-default"}`}
-                      onClick={onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? () => onEmojiClick(reaction.emoji_name) : undefined}
-                    >
-                      <EmojiDisplay
-                        name={reaction.emoji_name}
-                        customEmojiUrls={customEmojiUrls}
-                      />
-                      <div className="min-w-0">
-                        <p className="text-xs font-medium truncate">
-                          :{reaction.emoji_name}:
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {reaction.total_count.toLocaleString()}
-                        </p>
+        <div className="px-3 pb-3 pt-1 space-y-3">
+          {/* Top emojis */}
+          <div>
+            <p className="text-xs text-muted-foreground mb-2 font-medium">Most reacted emojis</p>
+            <TooltipProvider delayDuration={200}>
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2">
+                {item.top_reactions.map((reaction) => (
+                  <Tooltip key={reaction.emoji_name}>
+                    <TooltipTrigger asChild>
+                      <div
+                        className={`flex items-center gap-2 rounded-md bg-muted/40 px-2.5 py-1.5 ${onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? "cursor-pointer hover:bg-muted/60" : "cursor-default"}`}
+                        onClick={onEmojiClick && customEmojiUrls.has(reaction.emoji_name) ? () => onEmojiClick(reaction.emoji_name) : undefined}
+                      >
+                        <EmojiDisplay
+                          name={reaction.emoji_name}
+                          customEmojiUrls={customEmojiUrls}
+                        />
+                        <div className="min-w-0">
+                          <p className="text-xs font-medium truncate">
+                            :{reaction.emoji_name}:
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {reaction.total_count.toLocaleString()}
+                          </p>
+                        </div>
                       </div>
-                    </div>
-                  </TooltipTrigger>
-                  <TooltipContent side="top">
-                    <p className="font-medium">:{reaction.emoji_name}:</p>
-                    <p className="text-xs text-muted-foreground">{reaction.total_count.toLocaleString()} reactions</p>
-                  </TooltipContent>
-                </Tooltip>
-              ))}
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      <p className="font-medium">:{reaction.emoji_name}:</p>
+                      <p className="text-xs text-muted-foreground">{reaction.total_count.toLocaleString()} reactions</p>
+                    </TooltipContent>
+                  </Tooltip>
+                ))}
+              </div>
+            </TooltipProvider>
+          </div>
+
+          {/* Top reactors in this channel */}
+          {namedReactors.length > 0 && (
+            <div>
+              <p className="text-xs text-muted-foreground mb-2 font-medium">Top reactors</p>
+              <div className="flex flex-wrap gap-2">
+                {namedReactors.map((reactor) => {
+                  const name = userNameMap.get(reactor.user_id)
+                  return (
+                    <Badge key={reactor.user_id} variant="outline" className="gap-1.5 text-xs font-normal py-1">
+                      <span className="font-medium">{name?.split(" ")[0]}</span>
+                      <span className="text-muted-foreground">{reactor.reaction_count}</span>
+                    </Badge>
+                  )
+                })}
+              </div>
             </div>
-          </TooltipProvider>
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>
@@ -125,10 +154,21 @@ export function ChannelBreakdown({
   breakdown,
   channels,
   customEmojiUrls,
+  emojiData,
   onEmojiClick,
 }: ChannelBreakdownProps) {
   const channelMap = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels])
   const sorted = useMemo(() => [...breakdown].sort((a, b) => b.total_count - a.total_count), [breakdown])
+
+  const userNameMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const emoji of emojiData) {
+      if (emoji.user_id && emoji.user_display_name && !map.has(emoji.user_id)) {
+        map.set(emoji.user_id, emoji.user_display_name)
+      }
+    }
+    return map
+  }, [emojiData])
 
   if (breakdown.length === 0) return null
 
@@ -144,6 +184,7 @@ export function ChannelBreakdown({
             item={item}
             channel={channelMap.get(item.channel_id)}
             customEmojiUrls={customEmojiUrls}
+            userNameMap={userNameMap}
             onEmojiClick={onEmojiClick}
           />
         ))}

--- a/app/reactions/components/channel-breakdown.tsx
+++ b/app/reactions/components/channel-breakdown.tsx
@@ -17,13 +17,12 @@ import {
 import { Hash, Lock, ChevronDown, ChevronRight } from "lucide-react"
 import type { ChannelReactionBreakdown } from "@/lib/services/reaction-service"
 import type { SlackChannel } from "@/app/reactions/hooks/use-reactions-state"
-import type { Emoji } from "@/lib/services/emoji-service"
 
 interface ChannelBreakdownProps {
   breakdown: ChannelReactionBreakdown[]
   channels: SlackChannel[]
   customEmojiUrls: Map<string, string>
-  emojiData: Emoji[]
+  userNameMap: Map<string, string>
   onEmojiClick?: (name: string) => void
 }
 
@@ -154,21 +153,11 @@ export function ChannelBreakdown({
   breakdown,
   channels,
   customEmojiUrls,
-  emojiData,
+  userNameMap,
   onEmojiClick,
 }: ChannelBreakdownProps) {
   const channelMap = useMemo(() => new Map(channels.map((c) => [c.id, c])), [channels])
   const sorted = useMemo(() => [...breakdown].sort((a, b) => b.total_count - a.total_count), [breakdown])
-
-  const userNameMap = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const emoji of emojiData) {
-      if (emoji.user_id && emoji.user_display_name && !map.has(emoji.user_id)) {
-        map.set(emoji.user_id, emoji.user_display_name)
-      }
-    }
-    return map
-  }, [emojiData])
 
   if (breakdown.length === 0) return null
 

--- a/app/reactions/components/channel-picker.tsx
+++ b/app/reactions/components/channel-picker.tsx
@@ -149,11 +149,17 @@ export function ChannelPicker({
           onValueChange={(v) => v && setDateRange(v as DateRange)}
           className="border rounded-md"
         >
-          <ToggleGroupItem value="7d" className="text-sm px-3 h-9">
+          <ToggleGroupItem value="24h" className="text-sm px-2.5 h-9">
+            24h
+          </ToggleGroupItem>
+          <ToggleGroupItem value="7d" className="text-sm px-2.5 h-9">
             7d
           </ToggleGroupItem>
-          <ToggleGroupItem value="30d" className="text-sm px-3 h-9">
+          <ToggleGroupItem value="30d" className="text-sm px-2.5 h-9">
             30d
+          </ToggleGroupItem>
+          <ToggleGroupItem value="90d" className="text-sm px-2.5 h-9">
+            90d
           </ToggleGroupItem>
         </ToggleGroup>
 

--- a/app/reactions/components/channel-picker.tsx
+++ b/app/reactions/components/channel-picker.tsx
@@ -170,7 +170,7 @@ export function ChannelPicker({
           className="gap-2"
         >
           <Scan className="h-4 w-4" />
-          Scan Reactions
+          Scan Channels
         </Button>
       </div>
 

--- a/app/reactions/components/channel-picker.tsx
+++ b/app/reactions/components/channel-picker.tsx
@@ -2,10 +2,23 @@
 
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { Badge } from "@/components/ui/badge"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
-import { Search, Hash, Lock, X, Scan, ChevronDown } from "lucide-react"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command"
+import { Hash, Lock, X, Scan, ChevronDown, Check } from "lucide-react"
+import { cn } from "@/lib/utils"
 import type { SlackChannel, DateRange } from "@/app/reactions/hooks/use-reactions-state"
 
 interface ChannelPickerProps {
@@ -32,11 +45,6 @@ export function ChannelPicker({
   scanStatus,
 }: ChannelPickerProps) {
   const [open, setOpen] = useState(false)
-  const [search, setSearch] = useState("")
-
-  const filtered = channels.filter((c) =>
-    c.name.toLowerCase().includes(search.toLowerCase())
-  )
 
   function toggleChannel(id: string) {
     if (selectedChannels.includes(id)) {
@@ -57,90 +65,82 @@ export function ChannelPicker({
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
-        {/* Channel selector dropdown */}
-        <div className="relative">
-          <Button
-            variant="outline"
-            onClick={() => {
-              if (channels.length === 0 && !channelsLoading) {
-                fetchChannels()
-              }
-              setOpen((prev) => !prev)
-            }}
-            disabled={channelsLoading}
-            className="gap-2"
-          >
-            {channelsLoading ? (
-              <span className="text-muted-foreground">Loading channels…</span>
-            ) : (
-              <>
-                <Hash className="h-4 w-4" />
-                Select Channels
-                <ChevronDown className="h-4 w-4 text-muted-foreground" />
-              </>
-            )}
-          </Button>
-
-          {open && (
-            <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover shadow-lg">
-              <div className="p-2 border-b">
-                <div className="relative">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
-                  <Input
-                    className="pl-7 h-8 text-sm"
-                    placeholder="Search channels…"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    autoFocus
-                  />
-                </div>
-              </div>
-              <div className="max-h-56 overflow-y-auto py-1">
-                {filtered.length === 0 ? (
-                  <p className="px-3 py-2 text-sm text-muted-foreground">
-                    {channels.length === 0
-                      ? "No channels loaded. Click again to load."
-                      : "No channels match."}
-                  </p>
-                ) : (
-                  filtered.map((channel) => {
+        {/* Channel selector using Popover + Command */}
+        <Popover
+          open={open}
+          onOpenChange={(next) => {
+            if (next && channels.length === 0 && !channelsLoading) {
+              fetchChannels()
+            }
+            setOpen(next)
+          }}
+        >
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              disabled={channelsLoading}
+              className="gap-2"
+              role="combobox"
+              aria-expanded={open}
+            >
+              {channelsLoading ? (
+                <span className="text-muted-foreground">Loading channels…</span>
+              ) : (
+                <>
+                  <Hash className="h-4 w-4" />
+                  Select Channels
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                </>
+              )}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="start">
+            <Command>
+              <CommandInput placeholder="Search channels..." />
+              <CommandList>
+                <CommandEmpty>
+                  {channels.length === 0
+                    ? "No channels loaded. Close and click again to load."
+                    : "No channels found."}
+                </CommandEmpty>
+                <CommandGroup>
+                  {channels.map((channel) => {
                     const selected = selectedChannels.includes(channel.id)
                     return (
-                      <button
+                      <CommandItem
                         key={channel.id}
-                        onClick={() => toggleChannel(channel.id)}
-                        className={`flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent transition-colors ${
-                          selected ? "bg-accent/60 font-medium" : ""
-                        }`}
+                        value={channel.name}
+                        onSelect={() => toggleChannel(channel.id)}
+                        className="gap-2"
                       >
                         {channel.is_private ? (
                           <Lock className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                         ) : (
                           <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
                         )}
-                        <span className="flex-1 truncate text-left">
-                          {channel.name}
-                        </span>
+                        <span className="flex-1 truncate">{channel.name}</span>
                         <span className="text-xs text-muted-foreground shrink-0">
                           {channel.num_members.toLocaleString()}
                         </span>
-                      </button>
+                        <Check
+                          className={cn(
+                            "h-4 w-4 shrink-0",
+                            selected ? "opacity-100" : "opacity-0"
+                          )}
+                        />
+                      </CommandItem>
                     )
-                  })
-                )}
-              </div>
-              <div className="border-t p-2 flex justify-between items-center text-xs text-muted-foreground">
-                <span>{selectedChannels.length} selected</span>
-                <button
-                  className="hover:text-foreground transition-colors"
-                  onClick={() => setOpen(false)}
-                >
-                  Done
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
+                  })}
+                </CommandGroup>
+              </CommandList>
+              {selectedChannels.length > 0 && (
+                <div className="border-t px-3 py-2 text-xs text-muted-foreground">
+                  {selectedChannels.length} selected
+                </div>
+              )}
+            </Command>
+          </PopoverContent>
+        </Popover>
 
         {/* Date range toggle */}
         <ToggleGroup

--- a/app/reactions/components/channel-picker.tsx
+++ b/app/reactions/components/channel-picker.tsx
@@ -133,11 +133,23 @@ export function ChannelPicker({
                   })}
                 </CommandGroup>
               </CommandList>
-              {selectedChannels.length > 0 && (
-                <div className="border-t px-3 py-2 text-xs text-muted-foreground">
-                  {selectedChannels.length} selected
-                </div>
-              )}
+              <div className="border-t px-3 py-2 flex items-center justify-between">
+                <span className="text-xs text-muted-foreground">
+                  {selectedChannels.length} of {channels.length} selected
+                </span>
+                <button
+                  onClick={() => {
+                    if (selectedChannels.length === channels.length) {
+                      setSelectedChannels([])
+                    } else {
+                      setSelectedChannels(channels.map((c) => c.id))
+                    }
+                  }}
+                  className="text-xs font-medium text-primary hover:underline"
+                >
+                  {selectedChannels.length === channels.length ? "Deselect all" : "Select all"}
+                </button>
+              </div>
             </Command>
           </PopoverContent>
         </Popover>

--- a/app/reactions/components/channel-picker.tsx
+++ b/app/reactions/components/channel-picker.tsx
@@ -1,0 +1,199 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Badge } from "@/components/ui/badge"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Search, Hash, Lock, X, Scan, ChevronDown } from "lucide-react"
+import type { SlackChannel, DateRange } from "@/app/reactions/hooks/use-reactions-state"
+
+interface ChannelPickerProps {
+  channels: SlackChannel[]
+  selectedChannels: string[]
+  setSelectedChannels: (channels: string[]) => void
+  channelsLoading: boolean
+  fetchChannels: () => void
+  dateRange: DateRange
+  setDateRange: (range: DateRange) => void
+  onScan: () => void
+  scanStatus: "idle" | "scanning" | "complete" | "error"
+}
+
+export function ChannelPicker({
+  channels,
+  selectedChannels,
+  setSelectedChannels,
+  channelsLoading,
+  fetchChannels,
+  dateRange,
+  setDateRange,
+  onScan,
+  scanStatus,
+}: ChannelPickerProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  const filtered = channels.filter((c) =>
+    c.name.toLowerCase().includes(search.toLowerCase())
+  )
+
+  function toggleChannel(id: string) {
+    if (selectedChannels.includes(id)) {
+      setSelectedChannels(selectedChannels.filter((c) => c !== id))
+    } else {
+      setSelectedChannels([...selectedChannels, id])
+    }
+  }
+
+  function removeChannel(id: string) {
+    setSelectedChannels(selectedChannels.filter((c) => c !== id))
+  }
+
+  const selectedChannelObjects = channels.filter((c) =>
+    selectedChannels.includes(c.id)
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Channel selector dropdown */}
+        <div className="relative">
+          <Button
+            variant="outline"
+            onClick={() => {
+              if (channels.length === 0 && !channelsLoading) {
+                fetchChannels()
+              }
+              setOpen((prev) => !prev)
+            }}
+            disabled={channelsLoading}
+            className="gap-2"
+          >
+            {channelsLoading ? (
+              <span className="text-muted-foreground">Loading channels…</span>
+            ) : (
+              <>
+                <Hash className="h-4 w-4" />
+                Select Channels
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              </>
+            )}
+          </Button>
+
+          {open && (
+            <div className="absolute left-0 top-full z-50 mt-1 w-72 rounded-md border bg-popover shadow-lg">
+              <div className="p-2 border-b">
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground" />
+                  <Input
+                    className="pl-7 h-8 text-sm"
+                    placeholder="Search channels…"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    autoFocus
+                  />
+                </div>
+              </div>
+              <div className="max-h-56 overflow-y-auto py-1">
+                {filtered.length === 0 ? (
+                  <p className="px-3 py-2 text-sm text-muted-foreground">
+                    {channels.length === 0
+                      ? "No channels loaded. Click again to load."
+                      : "No channels match."}
+                  </p>
+                ) : (
+                  filtered.map((channel) => {
+                    const selected = selectedChannels.includes(channel.id)
+                    return (
+                      <button
+                        key={channel.id}
+                        onClick={() => toggleChannel(channel.id)}
+                        className={`flex w-full items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent transition-colors ${
+                          selected ? "bg-accent/60 font-medium" : ""
+                        }`}
+                      >
+                        {channel.is_private ? (
+                          <Lock className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        ) : (
+                          <Hash className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        )}
+                        <span className="flex-1 truncate text-left">
+                          {channel.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground shrink-0">
+                          {channel.num_members.toLocaleString()}
+                        </span>
+                      </button>
+                    )
+                  })
+                )}
+              </div>
+              <div className="border-t p-2 flex justify-between items-center text-xs text-muted-foreground">
+                <span>{selectedChannels.length} selected</span>
+                <button
+                  className="hover:text-foreground transition-colors"
+                  onClick={() => setOpen(false)}
+                >
+                  Done
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Date range toggle */}
+        <ToggleGroup
+          type="single"
+          value={dateRange}
+          onValueChange={(v) => v && setDateRange(v as DateRange)}
+          className="border rounded-md"
+        >
+          <ToggleGroupItem value="7d" className="text-sm px-3 h-9">
+            7d
+          </ToggleGroupItem>
+          <ToggleGroupItem value="30d" className="text-sm px-3 h-9">
+            30d
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {/* Scan button */}
+        <Button
+          onClick={onScan}
+          disabled={scanStatus === "scanning" || selectedChannels.length === 0}
+          className="gap-2"
+        >
+          <Scan className="h-4 w-4" />
+          Scan Reactions
+        </Button>
+      </div>
+
+      {/* Selected channel badges */}
+      {selectedChannelObjects.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedChannelObjects.map((channel) => (
+            <Badge
+              key={channel.id}
+              variant="secondary"
+              className="gap-1 pr-1"
+            >
+              {channel.is_private ? (
+                <Lock className="h-3 w-3" />
+              ) : (
+                <Hash className="h-3 w-3" />
+              )}
+              {channel.name}
+              <button
+                onClick={() => removeChannel(channel.id)}
+                className="ml-0.5 rounded-full hover:bg-muted transition-colors p-0.5"
+                aria-label={`Remove ${channel.name}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/reactions/components/how-it-works-modal.tsx
+++ b/app/reactions/components/how-it-works-modal.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import { Info, Shield, Globe, HardDrive, Zap } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { InfoDrawerResponsive } from "@/components/info-drawer-responsive"
+
+const SECTIONS = [
+  {
+    icon: Zap,
+    color: "bg-primary/10 text-primary",
+    title: "How it works",
+    body: (
+      <>
+        Usage scanning reads message history from the Slack channels you select using the
+        Slack <code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> API.
+        It looks at emoji reactions on messages and aggregates them into charts
+        and leaderboards &mdash; it does not read or store message content.
+      </>
+    ),
+  },
+  {
+    icon: Shield,
+    color: "bg-green-500/10 text-green-500",
+    title: "Your credentials",
+    body: (
+      <>
+        Authentication uses the same Slack session you set up in Settings.
+        Your token is stored only in your browser&apos;s local storage and is never
+        sent to any third-party server. API calls are proxied through a
+        server-side route that <strong>only</strong> allows
+        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.list</code> and
+        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> &mdash;
+        no other Slack endpoints are reachable.
+      </>
+    ),
+  },
+  {
+    icon: HardDrive,
+    color: "bg-blue-500/10 text-blue-500",
+    title: "Data storage",
+    body: (
+      <>
+        All reaction data is processed entirely in your browser. Scan results are
+        cached locally so you don&apos;t have to re-scan every time. Nothing is uploaded
+        to any external server or database &mdash; your data stays on your device.
+      </>
+    ),
+  },
+  {
+    icon: Globe,
+    color: "bg-orange-500/10 text-orange-500",
+    title: "Rate limiting",
+    body: (
+      <>
+        Scans are rate-limited to avoid hitting Slack&apos;s API limits. Each channel
+        is scanned sequentially with a delay between requests. Larger channels or
+        longer date ranges will take more time.
+      </>
+    ),
+  },
+]
+
+export function HowItWorksModal() {
+  return (
+    <InfoDrawerResponsive
+      trigger={
+        <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground hover:text-foreground">
+          <Info className="h-4 w-4" />
+          <span className="sr-only">How this works</span>
+        </Button>
+      }
+      title="How Usage Scanning Works"
+      description="Understand how Emoji Studio scans your Slack workspace and keeps your data secure."
+    >
+      <div className="space-y-6 text-sm">
+        {SECTIONS.map((section) => (
+          <div key={section.title} className="flex gap-3">
+            <div className={`rounded-lg p-2 h-fit shrink-0 ${section.color}`}>
+              <section.icon className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="font-medium">{section.title}</p>
+              <p className="text-muted-foreground mt-1">{section.body}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </InfoDrawerResponsive>
+  )
+}

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -15,6 +15,7 @@ import type { ReactionStats } from "@/lib/services/reaction-service"
 interface ReactionStatsCardsProps {
   stats: ReactionStats
   customEmojiUrls: Map<string, string>
+  onEmojiClick?: (name: string) => void
 }
 
 /** Returns badge color classes based on positive/negative trend */
@@ -27,6 +28,7 @@ function trendBadgeColors(isPositive: boolean) {
 export function ReactionStatsCards({
   stats,
   customEmojiUrls,
+  onEmojiClick,
 }: ReactionStatsCardsProps) {
   if (stats.total_reactions === 0) return null
 
@@ -85,7 +87,10 @@ export function ReactionStatsCards({
         </CardHeader>
         <CardContent>
           {topEmoji ? (
-            <div className="flex items-center gap-2">
+            <div
+              className={`flex items-center gap-2 ${topUrl && onEmojiClick ? "cursor-pointer hover:opacity-80 transition-opacity" : ""}`}
+              onClick={topUrl && onEmojiClick ? () => onEmojiClick(topEmoji.emoji_name) : undefined}
+            >
               {topUrl && (
                 <img src={topUrl} alt={topEmoji.emoji_name} className="h-7 w-7 object-contain shrink-0" />
               )}

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -6,28 +6,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Activity, Hash, Crown, TrendingUp, TrendingDown } from "lucide-react"
 import type { ReactionStats } from "@/lib/services/reaction-service"
 
 interface ReactionStatsCardsProps {
   stats: ReactionStats
   customEmojiUrls: Map<string, string>
-}
-
-function EmojiDisplay({
-  name,
-  customEmojiUrls,
-}: {
-  name: string
-  customEmojiUrls: Map<string, string>
-}) {
-  const url = customEmojiUrls.get(name)
-  if (url) {
-    return (
-      // eslint-disable-next-line @next/next/no-img-element
-      <img src={url} alt={`:${name}:`} className="w-7 h-7 object-contain" />
-    )
-  }
-  return null
 }
 
 export function ReactionStatsCards({
@@ -37,72 +21,90 @@ export function ReactionStatsCards({
   if (stats.total_reactions === 0) return null
 
   const topEmoji = stats.top_reactions[0]
+  const topUrl = topEmoji ? customEmojiUrls.get(topEmoji.emoji_name) : undefined
 
-  // Compute "this week" count from trending recent_count sum as proxy
-  const thisWeekCount = stats.trending.reduce(
-    (sum, t) => sum + t.recent_count,
-    0
-  )
-  const thisWeekTrend =
-    stats.trending.length > 0
-      ? stats.trending.reduce((sum, t) => sum + t.change_percent, 0) /
-        stats.trending.length
-      : 0
-
-  const cards = [
-    {
-      title: "Total Reactions",
-      value: stats.total_reactions.toLocaleString(),
-      sub: `${stats.unique_users.toLocaleString()} unique users`,
-    },
-    {
-      title: "Unique Emojis",
-      value: stats.unique_emojis.toLocaleString(),
-      sub: "distinct emoji used",
-    },
-    {
-      title: "Most Popular",
-      value: topEmoji ? (
-        <div className="flex items-center gap-2">
-          <EmojiDisplay name={topEmoji.emoji_name} customEmojiUrls={customEmojiUrls} />
-          <span className="truncate">:{topEmoji.emoji_name}:</span>
-        </div>
-      ) : (
-        "—"
-      ),
-      sub: topEmoji
-        ? `${topEmoji.total_count.toLocaleString()} uses`
-        : undefined,
-    },
-    {
-      title: "This Week",
-      value: thisWeekCount.toLocaleString(),
-      sub:
-        thisWeekTrend !== 0
-          ? `${thisWeekTrend > 0 ? "+" : ""}${Math.round(thisWeekTrend)}% vs prior period`
-          : "no trend data",
-    },
-  ]
+  // Compute week-over-week trend
+  const thisWeekCount = stats.trending.reduce((sum, t) => sum + t.recent_count, 0)
+  const lastWeekCount = stats.trending.reduce((sum, t) => sum + t.previous_count, 0)
+  const weekTrend = lastWeekCount > 0
+    ? ((thisWeekCount - lastWeekCount) / lastWeekCount) * 100
+    : thisWeekCount > 0 ? 100 : 0
+  const trendPositive = weekTrend >= 0
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-      {cards.map((card) => (
-        <Card key={card.title}>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              {card.title}
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className={`font-bold leading-none ${typeof card.value === 'string' ? 'text-2xl' : 'text-base'}`}>
-              {card.value}
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-3">
+      {/* Total Reactions */}
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+            <Activity className="h-3.5 w-3.5" />
+            Total Reactions
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.total_reactions.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            from {stats.unique_users.toLocaleString()} users
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Unique Emojis */}
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+            <Hash className="h-3.5 w-3.5" />
+            Unique Emojis
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.unique_emojis.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            distinct emoji used
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Most Popular */}
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+            <Crown className="h-3.5 w-3.5" />
+            Most Popular
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {topEmoji ? (
+            <div className="flex items-center gap-2">
+              {topUrl && (
+                <img src={topUrl} alt={topEmoji.emoji_name} className="h-7 w-7 object-contain shrink-0" />
+              )}
+              <div className="min-w-0">
+                <p className="text-sm font-bold truncate">:{topEmoji.emoji_name}:</p>
+                <p className="text-xs text-muted-foreground">{topEmoji.total_count.toLocaleString()} uses</p>
+              </div>
             </div>
-            {card.sub && (
-              <p className="mt-1 text-xs text-muted-foreground">{card.sub}</p>
-            )}
-          </CardContent>
-        </Card>
-      ))}
+          ) : (
+            <span className="text-2xl font-bold">—</span>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* This Week */}
+      <Card>
+        <CardHeader className="pb-1">
+          <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+            {trendPositive ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
+            This Week
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{thisWeekCount.toLocaleString()}</div>
+          <p className={`text-xs mt-0.5 ${trendPositive ? "text-green-500" : "text-red-500"}`}>
+            {trendPositive ? "+" : ""}{Math.round(weekTrend)}% vs last week
+          </p>
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -16,20 +16,18 @@ interface ReactionStatsCardsProps {
 function EmojiDisplay({
   name,
   customEmojiUrls,
-  size = "text-2xl",
 }: {
   name: string
   customEmojiUrls: Map<string, string>
-  size?: string
 }) {
   const url = customEmojiUrls.get(name)
   if (url) {
     return (
       // eslint-disable-next-line @next/next/no-img-element
-      <img src={url} alt={`:${name}:`} className="w-8 h-8 object-contain" />
+      <img src={url} alt={`:${name}:`} className="w-7 h-7 object-contain" />
     )
   }
-  return <span className={size}>:{name}:</span>
+  return null
 }
 
 export function ReactionStatsCards({
@@ -67,9 +65,7 @@ export function ReactionStatsCards({
       value: topEmoji ? (
         <div className="flex items-center gap-2">
           <EmojiDisplay name={topEmoji.emoji_name} customEmojiUrls={customEmojiUrls} />
-          <span className="text-sm font-normal text-muted-foreground truncate max-w-[100px]">
-            :{topEmoji.emoji_name}:
-          </span>
+          <span className="truncate">:{topEmoji.emoji_name}:</span>
         </div>
       ) : (
         "—"
@@ -98,7 +94,9 @@ export function ReactionStatsCards({
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold leading-none">{card.value}</div>
+            <div className={`font-bold leading-none ${typeof card.value === 'string' ? 'text-2xl' : 'text-base'}`}>
+              {card.value}
+            </div>
             {card.sub && (
               <p className="mt-1 text-xs text-muted-foreground">{card.sub}</p>
             )}

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -1,17 +1,27 @@
 "use client"
 
+import { cn } from "@/lib/utils"
 import {
   Card,
   CardContent,
+  CardDescription,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
 import { Activity, Hash, Crown, TrendingUp, TrendingDown } from "lucide-react"
 import type { ReactionStats } from "@/lib/services/reaction-service"
 
 interface ReactionStatsCardsProps {
   stats: ReactionStats
   customEmojiUrls: Map<string, string>
+}
+
+/** Returns badge color classes based on positive/negative trend */
+function trendBadgeColors(isPositive: boolean) {
+  return isPositive
+    ? "text-green-600 bg-green-500/10 dark:text-green-400 dark:bg-green-500/20"
+    : "text-red-600 bg-red-500/10 dark:text-red-400 dark:bg-red-500/20"
 }
 
 export function ReactionStatsCards({
@@ -43,9 +53,9 @@ export function ReactionStatsCards({
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{stats.total_reactions.toLocaleString()}</div>
-          <p className="text-xs text-muted-foreground mt-0.5">
+          <CardDescription className="text-xs mt-0.5">
             from {stats.unique_users.toLocaleString()} users
-          </p>
+          </CardDescription>
         </CardContent>
       </Card>
 
@@ -59,9 +69,9 @@ export function ReactionStatsCards({
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{stats.unique_emojis.toLocaleString()}</div>
-          <p className="text-xs text-muted-foreground mt-0.5">
+          <CardDescription className="text-xs mt-0.5">
             distinct emoji used
-          </p>
+          </CardDescription>
         </CardContent>
       </Card>
 
@@ -81,7 +91,7 @@ export function ReactionStatsCards({
               )}
               <div className="min-w-0">
                 <p className="text-sm font-bold truncate">:{topEmoji.emoji_name}:</p>
-                <p className="text-xs text-muted-foreground">{topEmoji.total_count.toLocaleString()} uses</p>
+                <CardDescription className="text-xs">{topEmoji.total_count.toLocaleString()} uses</CardDescription>
               </div>
             </div>
           ) : (
@@ -93,16 +103,28 @@ export function ReactionStatsCards({
       {/* This Week */}
       <Card>
         <CardHeader className="pb-1">
-          <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-            {trendPositive ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
-            This Week
-          </CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
+              {trendPositive ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
+              This Week
+            </CardTitle>
+            <Badge
+              variant="secondary"
+              className={cn(
+                "font-mono text-[10px] px-1.5 py-0.5 h-5",
+                trendBadgeColors(trendPositive)
+              )}
+            >
+              {trendPositive ? <TrendingUp className="mr-0.5 h-3 w-3" /> : <TrendingDown className="mr-0.5 h-3 w-3" />}
+              {trendPositive ? "+" : ""}{Math.round(weekTrend)}%
+            </Badge>
+          </div>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{thisWeekCount.toLocaleString()}</div>
-          <p className={`text-xs mt-0.5 ${trendPositive ? "text-green-500" : "text-red-500"}`}>
-            {trendPositive ? "+" : ""}{Math.round(weekTrend)}% vs last week
-          </p>
+          <CardDescription className="text-xs mt-0.5">
+            vs last week
+          </CardDescription>
         </CardContent>
       </Card>
     </div>

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type { ReactionStats } from "@/lib/services/reaction-service"
+
+interface ReactionStatsCardsProps {
+  stats: ReactionStats
+  customEmojiUrls: Map<string, string>
+}
+
+function EmojiDisplay({
+  name,
+  customEmojiUrls,
+  size = "text-2xl",
+}: {
+  name: string
+  customEmojiUrls: Map<string, string>
+  size?: string
+}) {
+  const url = customEmojiUrls.get(name)
+  if (url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img src={url} alt={`:${name}:`} className="w-8 h-8 object-contain" />
+    )
+  }
+  return <span className={size}>:{name}:</span>
+}
+
+export function ReactionStatsCards({
+  stats,
+  customEmojiUrls,
+}: ReactionStatsCardsProps) {
+  if (stats.total_reactions === 0) return null
+
+  const topEmoji = stats.top_reactions[0]
+
+  // Compute "this week" count from trending recent_count sum as proxy
+  const thisWeekCount = stats.trending.reduce(
+    (sum, t) => sum + t.recent_count,
+    0
+  )
+  const thisWeekTrend =
+    stats.trending.length > 0
+      ? stats.trending.reduce((sum, t) => sum + t.change_percent, 0) /
+        stats.trending.length
+      : 0
+
+  const cards = [
+    {
+      title: "Total Reactions",
+      value: stats.total_reactions.toLocaleString(),
+      sub: `${stats.unique_users.toLocaleString()} unique users`,
+    },
+    {
+      title: "Unique Emojis",
+      value: stats.unique_emojis.toLocaleString(),
+      sub: "distinct emoji used",
+    },
+    {
+      title: "Most Popular",
+      value: topEmoji ? (
+        <div className="flex items-center gap-2">
+          <EmojiDisplay name={topEmoji.emoji_name} customEmojiUrls={customEmojiUrls} />
+          <span className="text-sm font-normal text-muted-foreground truncate max-w-[100px]">
+            :{topEmoji.emoji_name}:
+          </span>
+        </div>
+      ) : (
+        "—"
+      ),
+      sub: topEmoji
+        ? `${topEmoji.total_count.toLocaleString()} uses`
+        : undefined,
+    },
+    {
+      title: "This Week",
+      value: thisWeekCount.toLocaleString(),
+      sub:
+        thisWeekTrend !== 0
+          ? `${thisWeekTrend > 0 ? "+" : ""}${Math.round(thisWeekTrend)}% vs prior period`
+          : "no trend data",
+    },
+  ]
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      {cards.map((card) => (
+        <Card key={card.title}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              {card.title}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold leading-none">{card.value}</div>
+            {card.sub && (
+              <p className="mt-1 text-xs text-muted-foreground">{card.sub}</p>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/app/reactions/components/reaction-stats-cards.tsx
+++ b/app/reactions/components/reaction-stats-cards.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { cn } from "@/lib/utils"
+import { cn, trendBadgeColors } from "@/lib/utils"
 import {
   Card,
   CardContent,
@@ -16,13 +16,6 @@ interface ReactionStatsCardsProps {
   stats: ReactionStats
   customEmojiUrls: Map<string, string>
   onEmojiClick?: (name: string) => void
-}
-
-/** Returns badge color classes based on positive/negative trend */
-function trendBadgeColors(isPositive: boolean) {
-  return isPositive
-    ? "text-green-600 bg-green-500/10 dark:text-green-400 dark:bg-green-500/20"
-    : "text-red-600 bg-red-500/10 dark:text-red-400 dark:bg-red-500/20"
 }
 
 export function ReactionStatsCards({

--- a/app/reactions/components/reaction-timeline.tsx
+++ b/app/reactions/components/reaction-timeline.tsx
@@ -1,49 +1,29 @@
 "use client"
 
-import { useId } from "react"
 import {
-  ResponsiveContainer,
   AreaChart,
   Area,
   XAxis,
   YAxis,
   CartesianGrid,
-  Tooltip,
 } from "recharts"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
 
 interface ReactionTimelineProps {
   data: { date: string; count: number }[]
 }
 
-interface TooltipPayloadItem {
-  value: number
-  payload: { date: string; count: number }
-}
-
-function CustomTooltip({
-  active,
-  payload,
-  label,
-}: {
-  active?: boolean
-  payload?: TooltipPayloadItem[]
-  label?: string
-}) {
-  if (!active || !payload?.length) return null
-  return (
-    <div className="rounded-lg border bg-popover px-3 py-2 shadow-md text-sm">
-      <p className="font-medium">{label}</p>
-      <p className="text-muted-foreground">
-        {payload[0].value.toLocaleString()} reactions
-      </p>
-    </div>
-  )
-}
+const chartConfig = {
+  reactions: { label: "Reactions", color: "hsl(var(--chart-1))" },
+} satisfies ChartConfig
 
 export function ReactionTimeline({ data }: ReactionTimelineProps) {
-  const gradientId = useId().replace(/:/g, "")
-
   if (!data || data.length === 0) return null
 
   return (
@@ -52,21 +32,21 @@ export function ReactionTimeline({ data }: ReactionTimelineProps) {
         <CardTitle className="text-base">Reaction Activity</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={200}>
+        <ChartContainer config={chartConfig} className="aspect-auto h-[200px] w-full">
           <AreaChart
             data={data}
             margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
           >
             <defs>
-              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id="reactionsGradient" x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
-                  stopColor="hsl(var(--chart-1))"
+                  stopColor="var(--color-reactions)"
                   stopOpacity={0.3}
                 />
                 <stop
                   offset="95%"
-                  stopColor="hsl(var(--chart-1))"
+                  stopColor="var(--color-reactions)"
                   stopOpacity={0}
                 />
               </linearGradient>
@@ -78,29 +58,28 @@ export function ReactionTimeline({ data }: ReactionTimelineProps) {
             />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
               tickLine={false}
               axisLine={false}
               interval="preserveStartEnd"
             />
             <YAxis
-              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
               tickLine={false}
               axisLine={false}
               width={40}
             />
-            <Tooltip content={<CustomTooltip />} />
+            <ChartTooltip content={<ChartTooltipContent />} />
             <Area
               type="monotone"
               dataKey="count"
-              stroke="hsl(var(--chart-1))"
+              name="reactions"
+              stroke="var(--color-reactions)"
               strokeWidth={2}
-              fill={`url(#${gradientId})`}
+              fill="url(#reactionsGradient)"
               dot={false}
-              activeDot={{ r: 4, fill: "hsl(var(--chart-1))" }}
+              activeDot={{ r: 4, fill: "var(--color-reactions)" }}
             />
           </AreaChart>
-        </ResponsiveContainer>
+        </ChartContainer>
       </CardContent>
     </Card>
   )

--- a/app/reactions/components/reaction-timeline.tsx
+++ b/app/reactions/components/reaction-timeline.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useId } from "react"
 import {
   ResponsiveContainer,
   AreaChart,
@@ -41,6 +42,8 @@ function CustomTooltip({
 }
 
 export function ReactionTimeline({ data }: ReactionTimelineProps) {
+  const gradientId = useId().replace(/:/g, "")
+
   if (!data || data.length === 0) return null
 
   return (
@@ -55,7 +58,7 @@ export function ReactionTimeline({ data }: ReactionTimelineProps) {
             margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
           >
             <defs>
-              <linearGradient id="reactionGradient" x1="0" y1="0" x2="0" y2="1">
+              <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                 <stop
                   offset="5%"
                   stopColor="hsl(var(--chart-1))"
@@ -92,7 +95,7 @@ export function ReactionTimeline({ data }: ReactionTimelineProps) {
               dataKey="count"
               stroke="hsl(var(--chart-1))"
               strokeWidth={2}
-              fill="url(#reactionGradient)"
+              fill={`url(#${gradientId})`}
               dot={false}
               activeDot={{ r: 4, fill: "hsl(var(--chart-1))" }}
             />

--- a/app/reactions/components/reaction-timeline.tsx
+++ b/app/reactions/components/reaction-timeline.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+
+interface ReactionTimelineProps {
+  data: { date: string; count: number }[]
+}
+
+interface TooltipPayloadItem {
+  value: number
+  payload: { date: string; count: number }
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean
+  payload?: TooltipPayloadItem[]
+  label?: string
+}) {
+  if (!active || !payload?.length) return null
+  return (
+    <div className="rounded-lg border bg-popover px-3 py-2 shadow-md text-sm">
+      <p className="font-medium">{label}</p>
+      <p className="text-muted-foreground">
+        {payload[0].value.toLocaleString()} reactions
+      </p>
+    </div>
+  )
+}
+
+export function ReactionTimeline({ data }: ReactionTimelineProps) {
+  if (!data || data.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base">Reaction Activity</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={200}>
+          <AreaChart
+            data={data}
+            margin={{ top: 4, right: 8, bottom: 0, left: 0 }}
+          >
+            <defs>
+              <linearGradient id="reactionGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop
+                  offset="5%"
+                  stopColor="hsl(var(--chart-1))"
+                  stopOpacity={0.3}
+                />
+                <stop
+                  offset="95%"
+                  stopColor="hsl(var(--chart-1))"
+                  stopOpacity={0}
+                />
+              </linearGradient>
+            </defs>
+            <CartesianGrid
+              strokeDasharray="3 3"
+              vertical={false}
+              stroke="hsl(var(--border))"
+            />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Area
+              type="monotone"
+              dataKey="count"
+              stroke="hsl(var(--chart-1))"
+              strokeWidth={2}
+              fill="url(#reactionGradient)"
+              dot={false}
+              activeDot={{ r: 4, fill: "hsl(var(--chart-1))" }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/reaction-timeline.tsx
+++ b/app/reactions/components/reaction-timeline.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useMemo } from "react"
 import {
   AreaChart,
   Area,
@@ -7,7 +8,13 @@ import {
   YAxis,
   CartesianGrid,
 } from "recharts"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
 import {
   type ChartConfig,
   ChartContainer,
@@ -26,12 +33,36 @@ const chartConfig = {
 export function ReactionTimeline({ data }: ReactionTimelineProps) {
   if (!data || data.length === 0) return null
 
+  const { total, peak } = useMemo(() => {
+    let total = 0
+    let peak = { date: "", count: 0 }
+    for (const d of data) {
+      total += d.count
+      if (d.count > peak.count) peak = d
+    }
+    return { total, peak }
+  }, [data])
+
   return (
     <Card>
-      <CardHeader className="pb-4">
-        <CardTitle className="text-base">Reaction Activity</CardTitle>
+      <CardHeader className="flex flex-col items-stretch space-y-0 border-b p-0 sm:flex-row">
+        <div className="flex flex-1 flex-col justify-center gap-1 px-6 py-5 sm:py-6">
+          <CardTitle className="text-base">Reaction Activity</CardTitle>
+          <CardDescription>
+            {total.toLocaleString()} total reactions over the scanned period
+          </CardDescription>
+        </div>
+        {peak.date && (
+          <div className="flex items-center justify-center border-t px-6 py-3 sm:border-l sm:border-t-0 sm:py-0">
+            <div className="text-center">
+              <p className="text-xs text-muted-foreground">Peak</p>
+              <p className="text-lg font-bold tabular-nums">{peak.count.toLocaleString()}</p>
+              <p className="text-xs text-muted-foreground">{peak.date}</p>
+            </div>
+          </div>
+        )}
       </CardHeader>
-      <CardContent>
+      <CardContent className="px-2 pt-4 sm:px-6 sm:pt-6">
         <ChartContainer config={chartConfig} className="aspect-auto h-[200px] w-full">
           <AreaChart
             data={data}
@@ -61,22 +92,25 @@ export function ReactionTimeline({ data }: ReactionTimelineProps) {
               tickLine={false}
               axisLine={false}
               interval="preserveStartEnd"
+              tickMargin={8}
             />
             <YAxis
               tickLine={false}
               axisLine={false}
               width={40}
             />
-            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartTooltip
+              content={<ChartTooltipContent indicator="line" />}
+            />
             <Area
-              type="monotone"
+              type="natural"
               dataKey="count"
               name="reactions"
               stroke="var(--color-reactions)"
               strokeWidth={2}
               fill="url(#reactionsGradient)"
               dot={false}
-              activeDot={{ r: 4, fill: "var(--color-reactions)" }}
+              activeDot={{ r: 4, fill: "var(--color-reactions)", strokeWidth: 0 }}
             />
           </AreaChart>
         </ChartContainer>

--- a/app/reactions/components/scan-progress.tsx
+++ b/app/reactions/components/scan-progress.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
-import { X, Loader2 } from "lucide-react"
+import { X, Check, Hash, Radio } from "lucide-react"
 
 interface ScanProgressProps {
   status: "idle" | "scanning" | "complete" | "error"
@@ -10,6 +10,7 @@ interface ScanProgressProps {
   channelsTotal: number
   reactionsFound: number
   onCancel: () => void
+  scannedChannels?: string[]
 }
 
 export function ScanProgress({
@@ -19,6 +20,7 @@ export function ScanProgress({
   channelsTotal,
   reactionsFound,
   onCancel,
+  scannedChannels = [],
 }: ScanProgressProps) {
   if (status !== "scanning") return null
 
@@ -26,53 +28,85 @@ export function ScanProgress({
     channelsTotal > 0 ? Math.round((channelsDone / channelsTotal) * 100) : 0
 
   return (
-    <div className="rounded-lg border bg-card p-4 space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2 text-sm">
-          <Loader2 className="h-4 w-4 animate-spin text-primary shrink-0" />
-          <span className="font-medium">
-            {currentChannel ? (
-              <>
-                Scanning{" "}
-                <span className="text-primary">#{currentChannel}</span>
-                {channelsTotal > 0 && (
-                  <span className="text-muted-foreground ml-1">
-                    ({channelsDone + 1}/{channelsTotal} channels)
-                  </span>
-                )}
-              </>
-            ) : (
-              "Starting scan…"
-            )}
-          </span>
+    <div className="rounded-xl border bg-card overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 pt-4 pb-2">
+        <div className="flex items-center gap-2.5">
+          <div className="relative flex items-center justify-center">
+            <Radio className="h-4 w-4 text-primary animate-pulse" />
+            <span className="absolute h-6 w-6 rounded-full bg-primary/10 animate-ping" />
+          </div>
+          <div className="text-sm font-medium">
+            Scanning channels
+            <span className="inline-flex w-6 text-muted-foreground">
+              <span className="animate-[ellipsis_1.5s_infinite]">...</span>
+            </span>
+          </div>
         </div>
         <Button
           variant="ghost"
           size="sm"
           onClick={onCancel}
-          className="h-7 w-7 p-0 shrink-0"
+          className="h-7 w-7 p-0 shrink-0 text-muted-foreground hover:text-foreground"
           aria-label="Cancel scan"
         >
           <X className="h-4 w-4" />
         </Button>
       </div>
 
-      {/* Progress bar */}
-      <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
-        <div
-          className="h-full bg-primary rounded-full transition-all duration-300"
-          style={{ width: `${percent}%` }}
-        />
+      {/* Channel segments */}
+      <div className="px-4 py-2">
+        <div className="flex gap-1 h-2 rounded-full overflow-hidden bg-muted">
+          {Array.from({ length: channelsTotal }).map((_, i) => (
+            <div
+              key={i}
+              className={`flex-1 rounded-full transition-all duration-500 ${
+                i < channelsDone
+                  ? "bg-primary"
+                  : i === channelsDone
+                    ? "bg-primary/60 animate-pulse"
+                    : "bg-transparent"
+              }`}
+            />
+          ))}
+        </div>
       </div>
 
-      <div className="flex items-center justify-between text-xs text-muted-foreground">
-        <span>
-          {channelsDone} of {channelsTotal} channels scanned
-        </span>
-        <span>
+      {/* Channel list */}
+      <div className="px-4 pb-3 space-y-1">
+        {scannedChannels.map((name) => (
+          <div key={name} className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Check className="h-3 w-3 text-primary shrink-0" />
+            <Hash className="h-3 w-3 shrink-0" />
+            <span>{name}</span>
+          </div>
+        ))}
+        {currentChannel && (
+          <div className="flex items-center gap-2 text-xs font-medium text-foreground">
+            <Radio className="h-3 w-3 text-primary animate-pulse shrink-0" />
+            <Hash className="h-3 w-3 shrink-0" />
+            <span>{currentChannel}</span>
+          </div>
+        )}
+      </div>
+
+      {/* Footer stats */}
+      <div className="flex items-center justify-between px-4 py-2.5 bg-muted/30 border-t text-xs text-muted-foreground">
+        <span>{channelsDone}/{channelsTotal} channels</span>
+        <span className="tabular-nums font-medium text-foreground">
           {reactionsFound.toLocaleString()} reactions found
         </span>
+        <span>{percent}%</span>
       </div>
+
+      <style jsx>{`
+        @keyframes ellipsis {
+          0% { content: ''; }
+          25% { content: '.'; }
+          50% { content: '..'; }
+          75% { content: '...'; }
+        }
+      `}</style>
     </div>
   )
 }

--- a/app/reactions/components/scan-progress.tsx
+++ b/app/reactions/components/scan-progress.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { X, Loader2 } from "lucide-react"
+
+interface ScanProgressProps {
+  status: "idle" | "scanning" | "complete" | "error"
+  currentChannel: string
+  channelsDone: number
+  channelsTotal: number
+  reactionsFound: number
+  onCancel: () => void
+}
+
+export function ScanProgress({
+  status,
+  currentChannel,
+  channelsDone,
+  channelsTotal,
+  reactionsFound,
+  onCancel,
+}: ScanProgressProps) {
+  if (status !== "scanning") return null
+
+  const percent =
+    channelsTotal > 0 ? Math.round((channelsDone / channelsTotal) * 100) : 0
+
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin text-primary shrink-0" />
+          <span className="font-medium">
+            {currentChannel ? (
+              <>
+                Scanning{" "}
+                <span className="text-primary">#{currentChannel}</span>
+                {channelsTotal > 0 && (
+                  <span className="text-muted-foreground ml-1">
+                    ({channelsDone + 1}/{channelsTotal} channels)
+                  </span>
+                )}
+              </>
+            ) : (
+              "Starting scan…"
+            )}
+          </span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          className="h-7 w-7 p-0 shrink-0"
+          aria-label="Cancel scan"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Progress bar */}
+      <div className="w-full h-2 rounded-full bg-muted overflow-hidden">
+        <div
+          className="h-full bg-primary rounded-full transition-all duration-300"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {channelsDone} of {channelsTotal} channels scanned
+        </span>
+        <span>
+          {reactionsFound.toLocaleString()} reactions found
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/app/reactions/components/scan-progress.tsx
+++ b/app/reactions/components/scan-progress.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { Button } from "@/components/ui/button"
+import { Progress } from "@/components/ui/progress"
 import { X, Check, Hash, Radio } from "lucide-react"
 
 interface ScanProgressProps {
@@ -38,9 +39,7 @@ export function ScanProgress({
           </div>
           <div className="text-sm font-medium">
             Scanning channels
-            <span className="inline-flex w-6 text-muted-foreground">
-              <span className="animate-[ellipsis_1.5s_infinite]">...</span>
-            </span>
+            <span className="inline-flex w-6 text-muted-foreground animate-pulse">...</span>
           </div>
         </div>
         <Button
@@ -54,22 +53,9 @@ export function ScanProgress({
         </Button>
       </div>
 
-      {/* Channel segments */}
+      {/* Progress bar */}
       <div className="px-4 py-2">
-        <div className="flex gap-1 h-2 rounded-full overflow-hidden bg-muted">
-          {Array.from({ length: channelsTotal }).map((_, i) => (
-            <div
-              key={i}
-              className={`flex-1 rounded-full transition-all duration-500 ${
-                i < channelsDone
-                  ? "bg-primary"
-                  : i === channelsDone
-                    ? "bg-primary/60 animate-pulse"
-                    : "bg-transparent"
-              }`}
-            />
-          ))}
-        </div>
+        <Progress value={percent} className="h-2" />
       </div>
 
       {/* Channel list */}
@@ -98,15 +84,6 @@ export function ScanProgress({
         </span>
         <span>{percent}%</span>
       </div>
-
-      <style jsx>{`
-        @keyframes ellipsis {
-          0% { content: ''; }
-          25% { content: '.'; }
-          50% { content: '..'; }
-          75% { content: '...'; }
-        }
-      `}</style>
     </div>
   )
 }

--- a/app/reactions/components/share-card-generator.tsx
+++ b/app/reactions/components/share-card-generator.tsx
@@ -341,7 +341,10 @@ export function ShareCardGenerator({
 
   async function getBlob(): Promise<Blob | null> {
     const canvas = await generateCanvas(stats, topReactions, customEmojiUrls, channelNames, dateRange)
-    return new Promise(resolve => canvas.toBlob(blob => resolve(blob), "image/png"))
+    return new Promise(resolve => canvas.toBlob(blob => {
+      canvas.width = 0  // release GPU backing store
+      resolve(blob)
+    }, "image/png"))
   }
 
   async function handleDownload() {

--- a/app/reactions/components/share-card-generator.tsx
+++ b/app/reactions/components/share-card-generator.tsx
@@ -18,6 +18,8 @@ interface ShareCardGeneratorProps {
   customEmojiUrls: Map<string, string>
   channelNames: string[]
   dateRange: string
+  onDownload?: () => void
+  onCopy?: () => void
 }
 
 const CARD_W = 1200
@@ -333,6 +335,8 @@ export function ShareCardGenerator({
   customEmojiUrls,
   channelNames,
   dateRange,
+  onDownload,
+  onCopy,
 }: ShareCardGeneratorProps) {
   const [isGenerating, setIsGenerating] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -362,6 +366,7 @@ export function ShareCardGenerator({
       a.click()
       URL.revokeObjectURL(url)
       toast.success("Card downloaded!")
+      onDownload?.()
     } catch (err) {
       console.error("Download error:", err)
       toast.error("Failed to generate card")
@@ -383,6 +388,7 @@ export function ShareCardGenerator({
       ])
       setCopied(true)
       toast.success("Card copied to clipboard!")
+      onCopy?.()
       setTimeout(() => setCopied(false), 2000)
     } catch (err) {
       console.error("Copy error:", err)

--- a/app/reactions/components/share-card-generator.tsx
+++ b/app/reactions/components/share-card-generator.tsx
@@ -1,0 +1,431 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+import { Download, Copy, Share2, Check } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import type { AggregatedReaction, ReactionStats } from "@/lib/services/reaction-service"
+
+interface ShareCardGeneratorProps {
+  stats: ReactionStats
+  topReactions: AggregatedReaction[]
+  customEmojiUrls: Map<string, string>
+  channelNames: string[]
+  dateRange: string
+}
+
+const CARD_W = 1200
+const CARD_H = 630
+
+const BAR_COLORS = [
+  "#a855f7",
+  "#ec4899",
+  "#6366f1",
+  "#8b5cf6",
+  "#d946ef",
+  "#f43f5e",
+  "#7c3aed",
+  "#c026d3",
+  "#e879f9",
+  "#a21caf",
+]
+
+function loadImageSafe(src: string): Promise<HTMLImageElement | null> {
+  return new Promise(resolve => {
+    const img = new Image()
+    img.crossOrigin = "anonymous"
+    img.onload = () => resolve(img)
+    img.onerror = () => resolve(null)
+    img.src = src
+  })
+}
+
+function getEmojiImageUrl(emojiName: string, customEmojiUrls: Map<string, string>): string | null {
+  const custom = customEmojiUrls.get(emojiName)
+  if (custom) return custom
+
+  // Standard unicode emoji via Twemoji CDN
+  // Map common emoji names to code points
+  const codePoint = EMOJI_NAME_TO_CODEPOINT[emojiName]
+  if (codePoint) {
+    return `https://cdn.jsdelivr.net/gh/twitter/twemoji@14.0.2/assets/72x72/${codePoint}.png`
+  }
+
+  return null
+}
+
+// A small mapping of frequently used reaction emoji names to Twemoji code points
+const EMOJI_NAME_TO_CODEPOINT: Record<string, string> = {
+  thumbsup: "1f44d",
+  "+1": "1f44d",
+  thumbsdown: "1f44e",
+  "-1": "1f44e",
+  heart: "2764",
+  fire: "1f525",
+  tada: "1f389",
+  rocket: "1f680",
+  eyes: "1f440",
+  wave: "1f44b",
+  clap: "1f44f",
+  raised_hands: "1f64c",
+  pray: "1f64f",
+  muscle: "1f4aa",
+  100: "1f4af",
+  white_check_mark: "2705",
+  x: "274c",
+  warning: "26a0",
+  star: "2b50",
+  star2: "1f31f",
+  sparkles: "2728",
+  zap: "26a1",
+  boom: "1f4a5",
+  bulb: "1f4a1",
+  trophy: "1f3c6",
+  medal_sports: "1f3c5",
+  crown: "1f451",
+  gem: "1f48e",
+  moneybag: "1f4b0",
+  robot: "1f916",
+  brain: "1f9e0",
+  magic_wand: "1fa84",
+  partying_face: "1f973",
+  joy: "1f602",
+  sob: "1f62d",
+  thinking_face: "1f914",
+  exploding_head: "1f92f",
+  smiling_face_with_3_hearts: "1f970",
+  slightly_smiling_face: "1f642",
+  smile: "1f604",
+  laughing: "1f606",
+  wink: "1f609",
+  sunglasses: "1f60e",
+  innocent: "1f607",
+  sweat_smile: "1f605",
+  raised_hand: "270b",
+  point_up: "261d",
+  point_right: "1f449",
+  point_left: "1f448",
+  ok_hand: "1f44c",
+  v: "270c",
+  mega: "1f4e3",
+  loudspeaker: "1f4e2",
+  question: "2753",
+  exclamation: "2757",
+  checkered_flag: "1f3c1",
+  dart: "1f3af",
+  bell: "1f514",
+  no_bell: "1f515",
+  poop: "1f4a9",
+  unicorn: "1f984",
+  rainbow: "1f308",
+  sunny: "2600",
+  snowflake: "2744",
+  coffee: "2615",
+  pizza: "1f355",
+  hamburger: "1f354",
+  tada_balloon: "1f388",
+  gift: "1f381",
+  balloon: "1f388",
+  confetti_ball: "1f38a",
+}
+
+async function generateCanvas(
+  stats: ReactionStats,
+  topReactions: AggregatedReaction[],
+  customEmojiUrls: Map<string, string>,
+  channelNames: string[],
+  dateRange: string
+): Promise<HTMLCanvasElement> {
+  const canvas = document.createElement("canvas")
+  canvas.width = CARD_W
+  canvas.height = CARD_H
+
+  const ctx = canvas.getContext("2d")!
+
+  // --- Background ---
+  const bgGrad = ctx.createLinearGradient(0, 0, CARD_W, CARD_H)
+  bgGrad.addColorStop(0, "#0f172a")
+  bgGrad.addColorStop(0.5, "#1a0a2e")
+  bgGrad.addColorStop(1, "#0f172a")
+  ctx.fillStyle = bgGrad
+  ctx.fillRect(0, 0, CARD_W, CARD_H)
+
+  // Subtle radial purple glow
+  const radial = ctx.createRadialGradient(CARD_W * 0.15, CARD_H * 0.2, 0, CARD_W * 0.15, CARD_H * 0.2, 480)
+  radial.addColorStop(0, "rgba(168, 85, 247, 0.18)")
+  radial.addColorStop(1, "rgba(168, 85, 247, 0)")
+  ctx.fillStyle = radial
+  ctx.fillRect(0, 0, CARD_W, CARD_H)
+
+  const radial2 = ctx.createRadialGradient(CARD_W * 0.85, CARD_H * 0.8, 0, CARD_W * 0.85, CARD_H * 0.8, 380)
+  radial2.addColorStop(0, "rgba(236, 72, 153, 0.15)")
+  radial2.addColorStop(1, "rgba(236, 72, 153, 0)")
+  ctx.fillStyle = radial2
+  ctx.fillRect(0, 0, CARD_W, CARD_H)
+
+  // --- Left column header ---
+  const leftX = 60
+  const rightX = CARD_W / 2 + 20
+
+  // Title
+  ctx.font = "bold 52px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  ctx.fillStyle = "#ffffff"
+  ctx.fillText("Top Reactions", leftX, 90)
+
+  // Subtitle: channels + date range
+  const channelLabel =
+    channelNames.length === 0
+      ? ""
+      : channelNames.length <= 3
+        ? channelNames.map(n => `#${n}`).join(", ")
+        : `#${channelNames[0]}, #${channelNames[1]} +${channelNames.length - 2} more`
+  const dateLabel = dateRange === "7d" ? "Last 7 days" : "Last 30 days"
+  const subtitleParts = [channelLabel, dateLabel].filter(Boolean)
+
+  ctx.font = "22px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  ctx.fillStyle = "rgba(148, 163, 184, 0.9)"
+  ctx.fillText(subtitleParts.join("  ·  "), leftX, 130)
+
+  // Divider
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.15)"
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(leftX, 148)
+  ctx.lineTo(CARD_W - leftX, 148)
+  ctx.stroke()
+
+  // --- Reaction list ---
+  const top10 = topReactions.slice(0, 10)
+  const maxCount = top10[0]?.total_count ?? 1
+
+  const listStartY = 170
+  const rowH = 44
+  const barMaxWidth = 340
+  const emojiSize = 28
+  const rankW = 32
+  const emojiCol = leftX + rankW + 8
+  const nameCol = emojiCol + emojiSize + 10
+  const barCol = nameCol + 170
+  const countCol = barCol + barMaxWidth + 12
+
+  // Left column: items 1-5 | Right column: items 6-10
+  const colDefs = [
+    { startIdx: 0, endIdx: 5, xOff: 0 },
+    { startIdx: 5, endIdx: 10, xOff: CARD_W / 2 - leftX + 20 },
+  ]
+
+  for (const col of colDefs) {
+    for (let i = col.startIdx; i < Math.min(col.endIdx, top10.length); i++) {
+      const reaction = top10[i]
+      const rowY = listStartY + (i - col.startIdx) * rowH
+      const xBase = col.xOff
+
+      // Rank number
+      ctx.font = `bold 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif`
+      ctx.fillStyle = i < 3 ? BAR_COLORS[i] : "rgba(148, 163, 184, 0.6)"
+      ctx.textAlign = "right"
+      ctx.fillText(String(i + 1), leftX + xBase + rankW, rowY + 22)
+      ctx.textAlign = "left"
+
+      // Emoji image
+      const emojiUrl = getEmojiImageUrl(reaction.emoji_name, customEmojiUrls)
+      if (emojiUrl) {
+        const img = await loadImageSafe(emojiUrl)
+        if (img) {
+          ctx.drawImage(img, leftX + xBase + emojiCol - leftX, rowY, emojiSize, emojiSize)
+        } else {
+          // Fallback: colored circle
+          ctx.fillStyle = BAR_COLORS[i % BAR_COLORS.length]
+          ctx.beginPath()
+          ctx.arc(leftX + xBase + emojiCol - leftX + emojiSize / 2, rowY + emojiSize / 2, emojiSize / 2 - 1, 0, Math.PI * 2)
+          ctx.fill()
+        }
+      } else {
+        ctx.fillStyle = BAR_COLORS[i % BAR_COLORS.length]
+        ctx.beginPath()
+        ctx.arc(leftX + xBase + emojiCol - leftX + emojiSize / 2, rowY + emojiSize / 2, emojiSize / 2 - 1, 0, Math.PI * 2)
+        ctx.fill()
+      }
+
+      // Emoji name
+      ctx.font = "16px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      ctx.fillStyle = "rgba(226, 232, 240, 0.9)"
+      const displayName = `:${reaction.emoji_name}:`
+      const truncName = displayName.length > 18 ? displayName.slice(0, 15) + "…:" : displayName
+      ctx.fillText(truncName, leftX + xBase + nameCol - leftX, rowY + 20)
+
+      // Bar
+      const barW = Math.max(4, Math.round((reaction.total_count / maxCount) * barMaxWidth))
+      const barY = rowY + 27
+      const barH = 8
+      const barRadius = 4
+
+      // Bar background track
+      ctx.fillStyle = "rgba(148, 163, 184, 0.08)"
+      ctx.beginPath()
+      ctx.roundRect(leftX + xBase + barCol - leftX, barY, barMaxWidth, barH, barRadius)
+      ctx.fill()
+
+      // Bar fill
+      const barGrad = ctx.createLinearGradient(
+        leftX + xBase + barCol - leftX, 0,
+        leftX + xBase + barCol - leftX + barW, 0
+      )
+      barGrad.addColorStop(0, BAR_COLORS[i % BAR_COLORS.length])
+      barGrad.addColorStop(1, BAR_COLORS[(i + 2) % BAR_COLORS.length])
+      ctx.fillStyle = barGrad
+      ctx.beginPath()
+      ctx.roundRect(leftX + xBase + barCol - leftX, barY, barW, barH, barRadius)
+      ctx.fill()
+
+      // Count
+      ctx.font = "bold 16px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+      ctx.fillStyle = "rgba(226, 232, 240, 0.8)"
+      ctx.fillText(
+        reaction.total_count.toLocaleString(),
+        leftX + xBase + countCol - leftX,
+        rowY + 20
+      )
+    }
+  }
+
+  // --- Footer ---
+  const footerY = CARD_H - 52
+
+  // Footer divider
+  ctx.strokeStyle = "rgba(148, 163, 184, 0.12)"
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(leftX, footerY - 12)
+  ctx.lineTo(CARD_W - leftX, footerY - 12)
+  ctx.stroke()
+
+  // Footer stats
+  ctx.font = "18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  ctx.fillStyle = "rgba(148, 163, 184, 0.75)"
+  ctx.textAlign = "left"
+  ctx.fillText(
+    `${stats.total_reactions.toLocaleString()} total reactions  ·  ${stats.unique_emojis} unique emojis`,
+    leftX,
+    footerY + 16
+  )
+
+  // Branding
+  ctx.font = "bold 18px -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+  ctx.fillStyle = "rgba(168, 85, 247, 0.85)"
+  ctx.textAlign = "right"
+  ctx.fillText("Made with Emoji Studio", CARD_W - leftX, footerY + 16)
+
+  ctx.textAlign = "left"
+
+  return canvas
+}
+
+export function ShareCardGenerator({
+  stats,
+  topReactions,
+  customEmojiUrls,
+  channelNames,
+  dateRange,
+}: ShareCardGeneratorProps) {
+  const [isGenerating, setIsGenerating] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  if (stats.total_reactions === 0) return null
+
+  async function getBlob(): Promise<Blob | null> {
+    const canvas = await generateCanvas(stats, topReactions, customEmojiUrls, channelNames, dateRange)
+    return new Promise(resolve => canvas.toBlob(blob => resolve(blob), "image/png"))
+  }
+
+  async function handleDownload() {
+    setIsGenerating(true)
+    try {
+      const blob = await getBlob()
+      if (!blob) {
+        toast.error("Failed to generate card")
+        return
+      }
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = "reaction-stats.png"
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.success("Card downloaded!")
+    } catch (err) {
+      console.error("Download error:", err)
+      toast.error("Failed to generate card")
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  async function handleCopy() {
+    setIsGenerating(true)
+    try {
+      const blob = await getBlob()
+      if (!blob) {
+        toast.error("Failed to generate card")
+        return
+      }
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blob }),
+      ])
+      setCopied(true)
+      toast.success("Card copied to clipboard!")
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Copy error:", err)
+      toast.error("Copy failed — try Download instead")
+    } finally {
+      setIsGenerating(false)
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Share2 className="h-4 w-4 text-purple-500" />
+          Share Your Stats
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Generate a shareable 1200×630 PNG card with your top reactions. Share it in Slack, Twitter, or anywhere.
+        </p>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-wrap gap-3">
+          <Button
+            variant="default"
+            onClick={handleDownload}
+            disabled={isGenerating}
+            className="gap-2"
+          >
+            <Download className="h-4 w-4" />
+            {isGenerating ? "Generating…" : "Download PNG"}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleCopy}
+            disabled={isGenerating}
+            className="gap-2"
+          >
+            {copied ? (
+              <Check className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="h-4 w-4" />
+            )}
+            {copied ? "Copied!" : "Copy to Clipboard"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/top-creators.tsx
+++ b/app/reactions/components/top-creators.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useMemo } from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Crown } from "lucide-react"
+import type { AggregatedReaction } from "@/lib/services/reaction-service"
+import type { Emoji } from "@/lib/services/emoji-service"
+
+interface TopCreatorsProps {
+  topReactions: AggregatedReaction[]
+  emojiData: Emoji[]
+  customEmojiUrls: Map<string, string>
+}
+
+interface CreatorStat {
+  user_display_name: string
+  user_id: string
+  total_reactions: number
+  emoji_count: number
+  top_emojis: { name: string; url: string; reactions: number }[]
+}
+
+export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCreatorsProps) {
+  const creators = useMemo(() => {
+    // Build a lookup: emoji name -> creator info
+    const emojiCreatorMap = new Map<string, { user_id: string; user_display_name: string }>()
+    for (const emoji of emojiData) {
+      if (!emoji.is_alias && emoji.user_display_name) {
+        emojiCreatorMap.set(emoji.name, {
+          user_id: emoji.user_id,
+          user_display_name: emoji.user_display_name,
+        })
+      }
+    }
+
+    // Aggregate: for each creator, sum reactions across their emojis
+    const creatorMap = new Map<string, {
+      user_display_name: string
+      total_reactions: number
+      emojis: { name: string; url: string; reactions: number }[]
+    }>()
+
+    for (const reaction of topReactions) {
+      const creator = emojiCreatorMap.get(reaction.emoji_name)
+      if (!creator) continue // skip standard emoji or unknown creators
+
+      const existing = creatorMap.get(creator.user_id)
+      const emojiEntry = {
+        name: reaction.emoji_name,
+        url: customEmojiUrls.get(reaction.emoji_name) || "",
+        reactions: reaction.total_count,
+      }
+
+      if (existing) {
+        existing.total_reactions += reaction.total_count
+        existing.emojis.push(emojiEntry)
+      } else {
+        creatorMap.set(creator.user_id, {
+          user_display_name: creator.user_display_name,
+          total_reactions: reaction.total_count,
+          emojis: [emojiEntry],
+        })
+      }
+    }
+
+    // Sort by total reactions, take top 10
+    return Array.from(creatorMap.entries())
+      .map(([user_id, data]) => ({
+        user_id,
+        user_display_name: data.user_display_name,
+        total_reactions: data.total_reactions,
+        emoji_count: data.emojis.length,
+        top_emojis: data.emojis
+          .sort((a, b) => b.reactions - a.reactions)
+          .slice(0, 5),
+      }))
+      .sort((a, b) => b.total_reactions - a.total_reactions)
+      .slice(0, 10)
+  }, [topReactions, emojiData, customEmojiUrls])
+
+  if (creators.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Crown className="h-4 w-4" />
+          Top Emoji Creators by Reaction Usage
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {creators.map((creator, i) => (
+            <div
+              key={creator.user_id}
+              className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors"
+            >
+              {/* Rank */}
+              <span className="text-lg font-bold text-muted-foreground w-6 text-right shrink-0">
+                {i + 1}
+              </span>
+
+              {/* Creator info */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-sm truncate">
+                    {creator.user_display_name}
+                  </span>
+                  <span className="text-xs text-muted-foreground shrink-0">
+                    {creator.total_reactions.toLocaleString()} reactions on {creator.emoji_count} emoji{creator.emoji_count !== 1 ? "s" : ""}
+                  </span>
+                </div>
+
+                {/* Top emojis by this creator */}
+                <div className="flex items-center gap-1.5 mt-1">
+                  {creator.top_emojis.map((emoji) => (
+                    <div
+                      key={emoji.name}
+                      className="flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5"
+                      title={`:${emoji.name}: (${emoji.reactions} reactions)`}
+                    >
+                      {emoji.url ? (
+                        <img
+                          src={emoji.url}
+                          alt={emoji.name}
+                          className="h-4 w-4 object-contain"
+                        />
+                      ) : null}
+                      <span className="text-[10px] text-muted-foreground">
+                        {emoji.reactions}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Reaction bar */}
+              <div className="w-24 shrink-0 hidden sm:block">
+                <div className="w-full bg-muted rounded-full h-2">
+                  <div
+                    className="bg-primary h-2 rounded-full transition-all"
+                    style={{
+                      width: `${Math.max(4, (creator.total_reactions / creators[0].total_reactions) * 100)}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/top-creators.tsx
+++ b/app/reactions/components/top-creators.tsx
@@ -1,13 +1,7 @@
 "use client"
 
 import { useMemo } from "react"
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Crown } from "lucide-react"
 import {
   BarChart,
@@ -107,10 +101,12 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
           <Crown className="h-4 w-4" />
           Top Creators
         </CardTitle>
+        <CardDescription className="text-xs">
+          People whose custom emojis received the most reactions
+        </CardDescription>
       </CardHeader>
-      <CardContent className="flex-1 flex flex-col gap-4">
-        {/* Horizontal bar chart */}
-        <ChartContainer config={chartConfig} className="aspect-auto h-[240px] w-full">
+      <CardContent className="flex-1">
+        <ChartContainer config={chartConfig} className="aspect-auto h-[280px] w-full">
           <BarChart
             data={chartData}
             layout="vertical"
@@ -129,9 +125,9 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
             <ChartTooltip
               content={
                 <ChartTooltipContent
-                  labelFormatter={(_: string, payload: Array<{ payload?: { fullName?: string } }>) => {
+                  labelFormatter={(_: string, payload: Array<{ payload?: { fullName?: string; emojiCount?: number } }>) => {
                     const item = payload?.[0]?.payload
-                    return item?.fullName ?? ""
+                    return item ? `${item.fullName} (${item.emojiCount} emoji${item.emojiCount === 1 ? "" : "s"})` : ""
                   }}
                 />
               }
@@ -144,46 +140,6 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
             />
           </BarChart>
         </ChartContainer>
-
-        {/* Creator emoji badges below the chart */}
-        <div className="space-y-2">
-          {creators.slice(0, 5).map((creator, i) => (
-            <div key={creator.user_id} className="flex items-center gap-2">
-              <span className="text-xs font-semibold text-muted-foreground w-4 text-right tabular-nums shrink-0">
-                {i + 1}
-              </span>
-              <span className="text-xs font-medium truncate w-20 shrink-0">
-                {creator.user_display_name.split(" ")[0]}
-              </span>
-              <TooltipProvider delayDuration={200}>
-                <div className="flex items-center gap-1 flex-1 min-w-0">
-                  {creator.top_emojis.map((emoji) => (
-                    <Tooltip key={emoji.name}>
-                      <TooltipTrigger asChild>
-                        <div className="flex items-center gap-0.5 bg-muted/50 rounded px-1.5 py-0.5 cursor-default">
-                          {emoji.url ? (
-                            <img
-                              src={emoji.url}
-                              alt={emoji.name}
-                              className="h-4 w-4 object-contain"
-                            />
-                          ) : null}
-                          <span className="text-[10px] text-muted-foreground tabular-nums">
-                            {emoji.reactions}
-                          </span>
-                        </div>
-                      </TooltipTrigger>
-                      <TooltipContent side="top">
-                        <p className="font-medium">:{emoji.name}:</p>
-                        <p className="text-xs text-muted-foreground">{emoji.reactions.toLocaleString()} reactions</p>
-                      </TooltipContent>
-                    </Tooltip>
-                  ))}
-                </div>
-              </TooltipProvider>
-            </div>
-          ))}
-        </div>
       </CardContent>
     </Card>
   )

--- a/app/reactions/components/top-creators.tsx
+++ b/app/reactions/components/top-creators.tsx
@@ -2,6 +2,12 @@
 
 import { useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { Crown } from "lucide-react"
 import {
   BarChart,
@@ -149,26 +155,32 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
               <span className="text-xs font-medium truncate w-20 shrink-0">
                 {creator.user_display_name.split(" ")[0]}
               </span>
-              <div className="flex items-center gap-1 flex-1 min-w-0">
-                {creator.top_emojis.map((emoji) => (
-                  <div
-                    key={emoji.name}
-                    className="flex items-center gap-0.5 bg-muted/50 rounded px-1.5 py-0.5"
-                    title={`:${emoji.name}: (${emoji.reactions} reactions)`}
-                  >
-                    {emoji.url ? (
-                      <img
-                        src={emoji.url}
-                        alt={emoji.name}
-                        className="h-4 w-4 object-contain"
-                      />
-                    ) : null}
-                    <span className="text-[10px] text-muted-foreground tabular-nums">
-                      {emoji.reactions}
-                    </span>
-                  </div>
-                ))}
-              </div>
+              <TooltipProvider delayDuration={200}>
+                <div className="flex items-center gap-1 flex-1 min-w-0">
+                  {creator.top_emojis.map((emoji) => (
+                    <Tooltip key={emoji.name}>
+                      <TooltipTrigger asChild>
+                        <div className="flex items-center gap-0.5 bg-muted/50 rounded px-1.5 py-0.5 cursor-default">
+                          {emoji.url ? (
+                            <img
+                              src={emoji.url}
+                              alt={emoji.name}
+                              className="h-4 w-4 object-contain"
+                            />
+                          ) : null}
+                          <span className="text-[10px] text-muted-foreground tabular-nums">
+                            {emoji.reactions}
+                          </span>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        <p className="font-medium">:{emoji.name}:</p>
+                        <p className="text-xs text-muted-foreground">{emoji.reactions.toLocaleString()} reactions</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </div>
+              </TooltipProvider>
             </div>
           ))}
         </div>

--- a/app/reactions/components/top-creators.tsx
+++ b/app/reactions/components/top-creators.tsx
@@ -3,6 +3,19 @@
 import { useMemo } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Crown } from "lucide-react"
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+} from "recharts"
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
 import type { AggregatedReaction } from "@/lib/services/reaction-service"
 import type { Emoji } from "@/lib/services/emoji-service"
 
@@ -12,17 +25,12 @@ interface TopCreatorsProps {
   customEmojiUrls: Map<string, string>
 }
 
-interface CreatorStat {
-  user_display_name: string
-  user_id: string
-  total_reactions: number
-  emoji_count: number
-  top_emojis: { name: string; url: string; reactions: number }[]
-}
+const chartConfig = {
+  reactions: { label: "Reactions", color: "hsl(var(--chart-2))" },
+} satisfies ChartConfig
 
 export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCreatorsProps) {
   const creators = useMemo(() => {
-    // Build a lookup: emoji name -> creator info
     const emojiCreatorMap = new Map<string, { user_id: string; user_display_name: string }>()
     for (const emoji of emojiData) {
       if (!emoji.is_alias && emoji.user_display_name) {
@@ -33,7 +41,6 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
       }
     }
 
-    // Aggregate: for each creator, sum reactions across their emojis
     const creatorMap = new Map<string, {
       user_display_name: string
       total_reactions: number
@@ -42,7 +49,7 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
 
     for (const reaction of topReactions) {
       const creator = emojiCreatorMap.get(reaction.emoji_name)
-      if (!creator) continue // skip standard emoji or unknown creators
+      if (!creator) continue
 
       const existing = creatorMap.get(creator.user_id)
       const emojiEntry = {
@@ -63,7 +70,6 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
       }
     }
 
-    // Sort by total reactions, take top 10
     return Array.from(creatorMap.entries())
       .map(([user_id, data]) => ({
         user_id,
@@ -75,75 +81,93 @@ export function TopCreators({ topReactions, emojiData, customEmojiUrls }: TopCre
           .slice(0, 5),
       }))
       .sort((a, b) => b.total_reactions - a.total_reactions)
-      .slice(0, 10)
+      .slice(0, 8)
   }, [topReactions, emojiData, customEmojiUrls])
 
   if (creators.length === 0) return null
 
+  // Transform for recharts: horizontal bar chart with creator names on Y axis
+  const chartData = creators.map((c) => ({
+    name: c.user_display_name.split(" ")[0],
+    reactions: c.total_reactions,
+    fullName: c.user_display_name,
+    emojiCount: c.emoji_count,
+  }))
+
   return (
-    <Card>
+    <Card className="flex flex-col">
       <CardHeader className="pb-3">
         <CardTitle className="text-base flex items-center gap-2">
           <Crown className="h-4 w-4" />
-          Top Emoji Creators by Reaction Usage
+          Top Creators
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <div className="space-y-3">
-          {creators.map((creator, i) => (
-            <div
-              key={creator.user_id}
-              className="flex items-center gap-3 p-2 rounded-lg hover:bg-muted/50 transition-colors"
-            >
-              {/* Rank */}
-              <span className="text-lg font-bold text-muted-foreground w-6 text-right shrink-0">
+      <CardContent className="flex-1 flex flex-col gap-4">
+        {/* Horizontal bar chart */}
+        <ChartContainer config={chartConfig} className="aspect-auto h-[240px] w-full">
+          <BarChart
+            data={chartData}
+            layout="vertical"
+            margin={{ top: 0, right: 8, bottom: 0, left: 0 }}
+          >
+            <CartesianGrid horizontal={false} stroke="hsl(var(--border))" strokeDasharray="3 3" />
+            <XAxis type="number" tickLine={false} axisLine={false} />
+            <YAxis
+              type="category"
+              dataKey="name"
+              tickLine={false}
+              axisLine={false}
+              width={72}
+              tick={{ fontSize: 12 }}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(_: string, payload: Array<{ payload?: { fullName?: string } }>) => {
+                    const item = payload?.[0]?.payload
+                    return item?.fullName ?? ""
+                  }}
+                />
+              }
+            />
+            <Bar
+              dataKey="reactions"
+              name="reactions"
+              fill="var(--color-reactions)"
+              radius={[0, 4, 4, 0]}
+            />
+          </BarChart>
+        </ChartContainer>
+
+        {/* Creator emoji badges below the chart */}
+        <div className="space-y-2">
+          {creators.slice(0, 5).map((creator, i) => (
+            <div key={creator.user_id} className="flex items-center gap-2">
+              <span className="text-xs font-semibold text-muted-foreground w-4 text-right tabular-nums shrink-0">
                 {i + 1}
               </span>
-
-              {/* Creator info */}
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="font-semibold text-sm truncate">
-                    {creator.user_display_name}
-                  </span>
-                  <span className="text-xs text-muted-foreground shrink-0">
-                    {creator.total_reactions.toLocaleString()} reactions on {creator.emoji_count} emoji{creator.emoji_count !== 1 ? "s" : ""}
-                  </span>
-                </div>
-
-                {/* Top emojis by this creator */}
-                <div className="flex items-center gap-1.5 mt-1">
-                  {creator.top_emojis.map((emoji) => (
-                    <div
-                      key={emoji.name}
-                      className="flex items-center gap-1 bg-muted/50 rounded px-1.5 py-0.5"
-                      title={`:${emoji.name}: (${emoji.reactions} reactions)`}
-                    >
-                      {emoji.url ? (
-                        <img
-                          src={emoji.url}
-                          alt={emoji.name}
-                          className="h-4 w-4 object-contain"
-                        />
-                      ) : null}
-                      <span className="text-[10px] text-muted-foreground">
-                        {emoji.reactions}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              {/* Reaction bar */}
-              <div className="w-24 shrink-0 hidden sm:block">
-                <div className="w-full bg-muted rounded-full h-2">
+              <span className="text-xs font-medium truncate w-20 shrink-0">
+                {creator.user_display_name.split(" ")[0]}
+              </span>
+              <div className="flex items-center gap-1 flex-1 min-w-0">
+                {creator.top_emojis.map((emoji) => (
                   <div
-                    className="bg-primary h-2 rounded-full transition-all"
-                    style={{
-                      width: `${Math.max(4, (creator.total_reactions / creators[0].total_reactions) * 100)}%`,
-                    }}
-                  />
-                </div>
+                    key={emoji.name}
+                    className="flex items-center gap-0.5 bg-muted/50 rounded px-1.5 py-0.5"
+                    title={`:${emoji.name}: (${emoji.reactions} reactions)`}
+                  >
+                    {emoji.url ? (
+                      <img
+                        src={emoji.url}
+                        alt={emoji.name}
+                        className="h-4 w-4 object-contain"
+                      />
+                    ) : null}
+                    <span className="text-[10px] text-muted-foreground tabular-nums">
+                      {emoji.reactions}
+                    </span>
+                  </div>
+                ))}
               </div>
             </div>
           ))}

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -8,6 +8,13 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Progress } from "@/components/ui/progress"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { AggregatedReaction } from "@/lib/services/reaction-service"
 import type { Emoji } from "@/lib/services/emoji-service"
 import type { EmojiFilter } from "@/app/reactions/hooks/use-reactions-state"
@@ -79,65 +86,74 @@ export function TopReactionsChart({
               : "No data yet — run a scan first."}
           </p>
         ) : (
-          <div className="space-y-0.5">
-            {data.map((reaction, i) => {
-              const url = customEmojiUrls.get(reaction.emoji_name)
-              const isCustom = !!url
-              const creator = creatorMap.get(reaction.emoji_name)
-              const barPct = Math.max(3, (reaction.total_count / maxCount) * 100)
+          <TooltipProvider delayDuration={200}>
+            <div className="space-y-0.5">
+              {data.map((reaction, i) => {
+                const url = customEmojiUrls.get(reaction.emoji_name)
+                const isCustom = !!url
+                const creator = creatorMap.get(reaction.emoji_name)
+                const barPct = Math.max(3, (reaction.total_count / maxCount) * 100)
+                const barColor = BAR_COLORS[i % BAR_COLORS.length]
 
-              return (
-                <div
-                  key={reaction.emoji_name}
-                  className="flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors"
-                >
-                  {/* Rank */}
-                  <span className="text-xs font-semibold text-muted-foreground w-5 text-right tabular-nums shrink-0">
-                    {i + 1}
-                  </span>
+                return (
+                  <Tooltip key={reaction.emoji_name}>
+                    <TooltipTrigger asChild>
+                      <div className="flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors cursor-default">
+                        {/* Rank */}
+                        <span className="text-xs font-semibold text-muted-foreground w-5 text-right tabular-nums shrink-0">
+                          {i + 1}
+                        </span>
 
-                  <div className="h-7 w-7 shrink-0 flex items-center justify-center">
-                    {isCustom && (
-                      <img
-                        src={url}
-                        alt={reaction.emoji_name}
-                        className="h-6 w-6 object-contain"
-                      />
-                    )}
-                  </div>
+                        <div className="h-7 w-7 shrink-0 flex items-center justify-center">
+                          {isCustom && (
+                            <img
+                              src={url}
+                              alt={reaction.emoji_name}
+                              className="h-6 w-6 object-contain"
+                            />
+                          )}
+                        </div>
 
-                  <div className="w-32 sm:w-40 shrink-0 min-w-0">
-                    <p className="text-sm font-medium truncate leading-tight">
-                      :{reaction.emoji_name}:
-                    </p>
-                    {creator && (
-                      <p className="text-[10px] text-muted-foreground truncate leading-tight">
-                        by {creator.split(" ")[0]}
+                        <div className="w-32 sm:w-40 shrink-0 min-w-0">
+                          <p className="text-sm font-medium truncate leading-tight">
+                            :{reaction.emoji_name}:
+                          </p>
+                          {creator && (
+                            <p className="text-[10px] text-muted-foreground truncate leading-tight">
+                              by {creator.split(" ")[0]}
+                            </p>
+                          )}
+                        </div>
+
+                        {/* Bar — shadcn Progress with colored indicator */}
+                        <div className="flex-1 min-w-0 hidden sm:block">
+                          <Progress
+                            value={barPct}
+                            className="h-2.5 bg-muted/60"
+                            style={{ ["--progress-color" as string]: barColor }}
+                          />
+                        </div>
+
+                        {/* Count */}
+                        <span className="text-xs font-semibold tabular-nums shrink-0 ml-auto sm:ml-0 sm:w-12 text-right">
+                          {reaction.total_count.toLocaleString()}
+                        </span>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      <p className="font-medium">:{reaction.emoji_name}:</p>
+                      <p className="text-xs text-muted-foreground">
+                        {reaction.total_count.toLocaleString()} reactions from {reaction.unique_users} users
                       </p>
-                    )}
-                  </div>
-
-                  {/* Bar */}
-                  <div className="flex-1 min-w-0 hidden sm:block">
-                    <div className="w-full bg-muted/60 rounded-full h-2.5">
-                      <div
-                        className="h-2.5 rounded-full"
-                        style={{
-                          width: `${barPct}%`,
-                          backgroundColor: BAR_COLORS[i % BAR_COLORS.length],
-                        }}
-                      />
-                    </div>
-                  </div>
-
-                  {/* Count */}
-                  <span className="text-xs font-semibold tabular-nums shrink-0 ml-auto sm:ml-0 sm:w-12 text-right">
-                    {reaction.total_count.toLocaleString()}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
+                      {creator && (
+                        <p className="text-xs text-muted-foreground">Created by {creator}</p>
+                      )}
+                    </TooltipContent>
+                  </Tooltip>
+                )
+              })}
+            </div>
+          </TooltipProvider>
         )}
       </CardContent>
     </Card>

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -20,11 +20,11 @@ interface TopReactionsChartProps {
 }
 
 const BAR_COLORS = [
-  "bg-chart-1",
-  "bg-chart-2",
-  "bg-chart-3",
-  "bg-chart-4",
-  "bg-chart-5",
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
 ]
 
 export function TopReactionsChart({
@@ -123,8 +123,11 @@ export function TopReactionsChart({
                   <div className="flex-1 min-w-0">
                     <div className="w-full bg-muted rounded-full h-3">
                       <div
-                        className={`h-3 rounded-full transition-all ${BAR_COLORS[i % BAR_COLORS.length]}`}
-                        style={{ width: `${barPct}%` }}
+                        className="h-3 rounded-full transition-all"
+                        style={{
+                          width: `${barPct}%`,
+                          backgroundColor: BAR_COLORS[i % BAR_COLORS.length],
+                        }}
                       />
                     </div>
                   </div>

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -25,6 +25,7 @@ interface TopReactionsChartProps {
   setEmojiFilter: (filter: EmojiFilter) => void
   customEmojiUrls: Map<string, string>
   emojiData: Emoji[]
+  onEmojiClick?: (name: string) => void
 }
 
 const BAR_COLORS = [
@@ -41,6 +42,7 @@ export function TopReactionsChart({
   setEmojiFilter,
   customEmojiUrls,
   emojiData,
+  onEmojiClick,
 }: TopReactionsChartProps) {
   const filtered =
     emojiFilter === "custom"
@@ -98,7 +100,10 @@ export function TopReactionsChart({
                 return (
                   <Tooltip key={reaction.emoji_name}>
                     <TooltipTrigger asChild>
-                      <div className="flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors cursor-default">
+                      <div
+                        className={`flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors ${isCustom && onEmojiClick ? "cursor-pointer" : "cursor-default"}`}
+                        onClick={isCustom && onEmojiClick ? () => onEmojiClick(reaction.emoji_name) : undefined}
+                      >
                         {/* Rank */}
                         <span className="text-xs font-semibold text-muted-foreground w-5 text-right tabular-nums shrink-0">
                           {i + 1}

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -96,17 +96,17 @@ export function TopReactionsChart({
                     {i + 1}
                   </span>
 
-                  {isCustom && (
-                    <div className="h-7 w-7 shrink-0 flex items-center justify-center">
+                  <div className="h-7 w-7 shrink-0 flex items-center justify-center">
+                    {isCustom && (
                       <img
                         src={url}
                         alt={reaction.emoji_name}
                         className="h-6 w-6 object-contain"
                       />
-                    </div>
-                  )}
+                    )}
+                  </div>
 
-                  <div className={`${isCustom ? "w-32 sm:w-40" : "w-40 sm:w-48"} shrink-0 min-w-0`}>
+                  <div className="w-32 sm:w-40 shrink-0 min-w-0">
                     <p className="text-sm font-medium truncate leading-tight">
                       :{reaction.emoji_name}:
                     </p>

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Smile } from "lucide-react"
 import type { AggregatedReaction } from "@/lib/services/reaction-service"
 import type { Emoji } from "@/lib/services/emoji-service"
 import type { EmojiFilter } from "@/app/reactions/hooks/use-reactions-state"
@@ -42,7 +43,7 @@ export function TopReactionsChart({
   const data = filtered.slice(0, 20)
   const maxCount = data[0]?.total_count || 1
 
-  // Build creator lookup
+  // Build creator lookup from emoji data
   const creatorMap = new Map<string, string>()
   for (const emoji of emojiData) {
     if (!emoji.is_alias && emoji.user_display_name) {
@@ -76,54 +77,57 @@ export function TopReactionsChart({
               : "No data yet — run a scan first."}
           </p>
         ) : (
-          <div className="space-y-1.5">
+          <div className="space-y-0.5">
             {data.map((reaction, i) => {
               const url = customEmojiUrls.get(reaction.emoji_name)
+              const isCustom = !!url
               const creator = creatorMap.get(reaction.emoji_name)
-              const barPct = Math.max(2, (reaction.total_count / maxCount) * 100)
+              const barPct = Math.max(3, (reaction.total_count / maxCount) * 100)
 
               return (
                 <div
                   key={reaction.emoji_name}
-                  className="flex items-center gap-3 p-1.5 rounded-lg hover:bg-muted/50 transition-colors group"
+                  className="flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors"
                 >
                   {/* Rank */}
-                  <span className="text-sm font-bold text-muted-foreground w-5 text-right shrink-0">
+                  <span className="text-xs font-semibold text-muted-foreground w-5 text-right tabular-nums shrink-0">
                     {i + 1}
                   </span>
 
-                  {/* Emoji image */}
-                  <div className="h-8 w-8 shrink-0 flex items-center justify-center">
-                    {url ? (
+                  {/* Emoji image or placeholder */}
+                  <div className="h-7 w-7 shrink-0 flex items-center justify-center rounded bg-muted/50">
+                    {isCustom ? (
                       <img
                         src={url}
                         alt={reaction.emoji_name}
-                        className="h-7 w-7 object-contain rounded"
+                        className="h-6 w-6 object-contain"
                       />
                     ) : (
-                      <span className="text-lg" title={`:${reaction.emoji_name}:`}>
-                        :{reaction.emoji_name}:
-                      </span>
+                      <Smile className="h-4 w-4 text-muted-foreground" />
                     )}
                   </div>
 
                   {/* Name + creator */}
-                  <div className="min-w-0 w-36 shrink-0">
-                    <p className="text-sm font-medium truncate" title={`:${reaction.emoji_name}:`}>
+                  <div className="w-32 sm:w-40 shrink-0 min-w-0">
+                    <p className="text-sm font-medium truncate leading-tight">
                       :{reaction.emoji_name}:
                     </p>
-                    {creator && (
-                      <p className="text-[11px] text-muted-foreground truncate">
+                    {creator ? (
+                      <p className="text-[10px] text-muted-foreground truncate leading-tight">
                         by {creator.split(" ")[0]}
                       </p>
-                    )}
+                    ) : !isCustom ? (
+                      <p className="text-[10px] text-muted-foreground leading-tight">
+                        built-in
+                      </p>
+                    ) : null}
                   </div>
 
                   {/* Bar */}
-                  <div className="flex-1 min-w-0">
-                    <div className="w-full bg-muted rounded-full h-3">
+                  <div className="flex-1 min-w-0 hidden sm:block">
+                    <div className="w-full bg-muted/60 rounded-full h-2.5">
                       <div
-                        className="h-3 rounded-full transition-all"
+                        className="h-2.5 rounded-full"
                         style={{
                           width: `${barPct}%`,
                           backgroundColor: BAR_COLORS[i % BAR_COLORS.length],
@@ -133,7 +137,7 @@ export function TopReactionsChart({
                   </div>
 
                   {/* Count */}
-                  <span className="text-sm font-semibold tabular-nums w-14 text-right shrink-0">
+                  <span className="text-xs font-semibold tabular-nums shrink-0 ml-auto sm:ml-0 sm:w-12 text-right">
                     {reaction.total_count.toLocaleString()}
                   </span>
                 </div>

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -1,16 +1,6 @@
 "use client"
 
 import {
-  ResponsiveContainer,
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  Cell,
-} from "recharts"
-import {
   Card,
   CardContent,
   CardHeader,
@@ -18,6 +8,7 @@ import {
 } from "@/components/ui/card"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import type { AggregatedReaction } from "@/lib/services/reaction-service"
+import type { Emoji } from "@/lib/services/emoji-service"
 import type { EmojiFilter } from "@/app/reactions/hooks/use-reactions-state"
 
 interface TopReactionsChartProps {
@@ -25,62 +16,39 @@ interface TopReactionsChartProps {
   emojiFilter: EmojiFilter
   setEmojiFilter: (filter: EmojiFilter) => void
   customEmojiUrls: Map<string, string>
+  emojiData: Emoji[]
 }
 
-const CHART_COLORS = [
-  "hsl(var(--chart-1))",
-  "hsl(var(--chart-2))",
-  "hsl(var(--chart-3))",
-  "hsl(var(--chart-4))",
-  "hsl(var(--chart-5))",
+const BAR_COLORS = [
+  "bg-chart-1",
+  "bg-chart-2",
+  "bg-chart-3",
+  "bg-chart-4",
+  "bg-chart-5",
 ]
-
-function isCustomEmoji(name: string, customEmojiUrls: Map<string, string>) {
-  return customEmojiUrls.has(name)
-}
-
-interface TooltipPayloadItem {
-  value: number
-  payload: { emoji_name: string; total_count: number }
-}
-
-function CustomTooltip({
-  active,
-  payload,
-}: {
-  active?: boolean
-  payload?: TooltipPayloadItem[]
-}) {
-  if (!active || !payload?.length) return null
-  const d = payload[0].payload
-  return (
-    <div className="rounded-lg border bg-popover px-3 py-2 shadow-md text-sm">
-      <p className="font-medium">:{d.emoji_name}:</p>
-      <p className="text-muted-foreground">
-        {d.total_count.toLocaleString()} reactions
-      </p>
-    </div>
-  )
-}
 
 export function TopReactionsChart({
   topReactions,
   emojiFilter,
   setEmojiFilter,
   customEmojiUrls,
+  emojiData,
 }: TopReactionsChartProps) {
   const filtered =
     emojiFilter === "custom"
-      ? topReactions.filter((r) =>
-          isCustomEmoji(r.emoji_name, customEmojiUrls)
-        )
+      ? topReactions.filter((r) => customEmojiUrls.has(r.emoji_name))
       : topReactions
 
-  const data = filtered.slice(0, 15).map((r) => ({
-    emoji_name: r.emoji_name,
-    total_count: r.total_count,
-    label: `:${r.emoji_name}:`,
-  }))
+  const data = filtered.slice(0, 20)
+  const maxCount = data[0]?.total_count || 1
+
+  // Build creator lookup
+  const creatorMap = new Map<string, string>()
+  for (const emoji of emojiData) {
+    if (!emoji.is_alias && emoji.user_display_name) {
+      creatorMap.set(emoji.name, emoji.user_display_name)
+    }
+  }
 
   return (
     <Card>
@@ -108,42 +76,67 @@ export function TopReactionsChart({
               : "No data yet — run a scan first."}
           </p>
         ) : (
-          <ResponsiveContainer width="100%" height={data.length * 32 + 20}>
-            <BarChart
-              data={data}
-              layout="vertical"
-              margin={{ top: 0, right: 16, bottom: 0, left: 8 }}
-            >
-              <CartesianGrid
-                strokeDasharray="3 3"
-                horizontal={false}
-                stroke="hsl(var(--border))"
-              />
-              <XAxis
-                type="number"
-                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <YAxis
-                type="category"
-                dataKey="label"
-                width={110}
-                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
-                tickLine={false}
-                axisLine={false}
-              />
-              <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--muted)/0.3)" }} />
-              <Bar dataKey="total_count" radius={[0, 4, 4, 0]} maxBarSize={24}>
-                {data.map((_, index) => (
-                  <Cell
-                    key={`cell-${index}`}
-                    fill={CHART_COLORS[index % CHART_COLORS.length]}
-                  />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
+          <div className="space-y-1.5">
+            {data.map((reaction, i) => {
+              const url = customEmojiUrls.get(reaction.emoji_name)
+              const creator = creatorMap.get(reaction.emoji_name)
+              const barPct = Math.max(2, (reaction.total_count / maxCount) * 100)
+
+              return (
+                <div
+                  key={reaction.emoji_name}
+                  className="flex items-center gap-3 p-1.5 rounded-lg hover:bg-muted/50 transition-colors group"
+                >
+                  {/* Rank */}
+                  <span className="text-sm font-bold text-muted-foreground w-5 text-right shrink-0">
+                    {i + 1}
+                  </span>
+
+                  {/* Emoji image */}
+                  <div className="h-8 w-8 shrink-0 flex items-center justify-center">
+                    {url ? (
+                      <img
+                        src={url}
+                        alt={reaction.emoji_name}
+                        className="h-7 w-7 object-contain rounded"
+                      />
+                    ) : (
+                      <span className="text-lg" title={`:${reaction.emoji_name}:`}>
+                        :{reaction.emoji_name}:
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Name + creator */}
+                  <div className="min-w-0 w-36 shrink-0">
+                    <p className="text-sm font-medium truncate" title={`:${reaction.emoji_name}:`}>
+                      :{reaction.emoji_name}:
+                    </p>
+                    {creator && (
+                      <p className="text-[11px] text-muted-foreground truncate">
+                        by {creator.split(" ")[0]}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Bar */}
+                  <div className="flex-1 min-w-0">
+                    <div className="w-full bg-muted rounded-full h-3">
+                      <div
+                        className={`h-3 rounded-full transition-all ${BAR_COLORS[i % BAR_COLORS.length]}`}
+                        style={{ width: `${barPct}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Count */}
+                  <span className="text-sm font-semibold tabular-nums w-14 text-right shrink-0">
+                    {reaction.total_count.toLocaleString()}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from "recharts"
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import type { AggregatedReaction } from "@/lib/services/reaction-service"
+import type { EmojiFilter } from "@/app/reactions/hooks/use-reactions-state"
+
+interface TopReactionsChartProps {
+  topReactions: AggregatedReaction[]
+  emojiFilter: EmojiFilter
+  setEmojiFilter: (filter: EmojiFilter) => void
+  customEmojiUrls: Map<string, string>
+}
+
+const CHART_COLORS = [
+  "hsl(var(--chart-1))",
+  "hsl(var(--chart-2))",
+  "hsl(var(--chart-3))",
+  "hsl(var(--chart-4))",
+  "hsl(var(--chart-5))",
+]
+
+function isCustomEmoji(name: string, customEmojiUrls: Map<string, string>) {
+  return customEmojiUrls.has(name)
+}
+
+interface TooltipPayloadItem {
+  value: number
+  payload: { emoji_name: string; total_count: number }
+}
+
+function CustomTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean
+  payload?: TooltipPayloadItem[]
+}) {
+  if (!active || !payload?.length) return null
+  const d = payload[0].payload
+  return (
+    <div className="rounded-lg border bg-popover px-3 py-2 shadow-md text-sm">
+      <p className="font-medium">:{d.emoji_name}:</p>
+      <p className="text-muted-foreground">
+        {d.total_count.toLocaleString()} reactions
+      </p>
+    </div>
+  )
+}
+
+export function TopReactionsChart({
+  topReactions,
+  emojiFilter,
+  setEmojiFilter,
+  customEmojiUrls,
+}: TopReactionsChartProps) {
+  const filtered =
+    emojiFilter === "custom"
+      ? topReactions.filter((r) =>
+          isCustomEmoji(r.emoji_name, customEmojiUrls)
+        )
+      : topReactions
+
+  const data = filtered.slice(0, 15).map((r) => ({
+    emoji_name: r.emoji_name,
+    total_count: r.total_count,
+    label: `:${r.emoji_name}:`,
+  }))
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-4">
+        <CardTitle className="text-base">Top Reactions</CardTitle>
+        <ToggleGroup
+          type="single"
+          value={emojiFilter}
+          onValueChange={(v) => v && setEmojiFilter(v as EmojiFilter)}
+          className="border rounded-md"
+        >
+          <ToggleGroupItem value="all" className="text-xs px-2.5 h-7">
+            All
+          </ToggleGroupItem>
+          <ToggleGroupItem value="custom" className="text-xs px-2.5 h-7">
+            Custom Only
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            {emojiFilter === "custom"
+              ? "No custom emoji found in scan results."
+              : "No data yet — run a scan first."}
+          </p>
+        ) : (
+          <ResponsiveContainer width="100%" height={data.length * 32 + 20}>
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 0, right: 16, bottom: 0, left: 8 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                horizontal={false}
+                stroke="hsl(var(--border))"
+              />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="label"
+                width={110}
+                tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--muted)/0.3)" }} />
+              <Bar dataKey="total_count" radius={[0, 4, 4, 0]} maxBarSize={24}>
+                {data.map((_, index) => (
+                  <Cell
+                    key={`cell-${index}`}
+                    fill={CHART_COLORS[index % CHART_COLORS.length]}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/top-reactions-chart.tsx
+++ b/app/reactions/components/top-reactions-chart.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useMemo } from "react"
 import {
   Card,
   CardContent,
@@ -7,7 +8,6 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
-import { Smile } from "lucide-react"
 import type { AggregatedReaction } from "@/lib/services/reaction-service"
 import type { Emoji } from "@/lib/services/emoji-service"
 import type { EmojiFilter } from "@/app/reactions/hooks/use-reactions-state"
@@ -43,13 +43,15 @@ export function TopReactionsChart({
   const data = filtered.slice(0, 20)
   const maxCount = data[0]?.total_count || 1
 
-  // Build creator lookup from emoji data
-  const creatorMap = new Map<string, string>()
-  for (const emoji of emojiData) {
-    if (!emoji.is_alias && emoji.user_display_name) {
-      creatorMap.set(emoji.name, emoji.user_display_name)
+  const creatorMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const emoji of emojiData) {
+      if (!emoji.is_alias && emoji.user_display_name) {
+        map.set(emoji.name, emoji.user_display_name)
+      }
     }
-  }
+    return map
+  }, [emojiData])
 
   return (
     <Card>
@@ -94,33 +96,25 @@ export function TopReactionsChart({
                     {i + 1}
                   </span>
 
-                  {/* Emoji image or placeholder */}
-                  <div className="h-7 w-7 shrink-0 flex items-center justify-center rounded bg-muted/50">
-                    {isCustom ? (
+                  {isCustom && (
+                    <div className="h-7 w-7 shrink-0 flex items-center justify-center">
                       <img
                         src={url}
                         alt={reaction.emoji_name}
                         className="h-6 w-6 object-contain"
                       />
-                    ) : (
-                      <Smile className="h-4 w-4 text-muted-foreground" />
-                    )}
-                  </div>
+                    </div>
+                  )}
 
-                  {/* Name + creator */}
-                  <div className="w-32 sm:w-40 shrink-0 min-w-0">
+                  <div className={`${isCustom ? "w-32 sm:w-40" : "w-40 sm:w-48"} shrink-0 min-w-0`}>
                     <p className="text-sm font-medium truncate leading-tight">
                       :{reaction.emoji_name}:
                     </p>
-                    {creator ? (
+                    {creator && (
                       <p className="text-[10px] text-muted-foreground truncate leading-tight">
                         by {creator.split(" ")[0]}
                       </p>
-                    ) : !isCustom ? (
-                      <p className="text-[10px] text-muted-foreground leading-tight">
-                        built-in
-                      </p>
-                    ) : null}
+                    )}
                   </div>
 
                   {/* Bar */}

--- a/app/reactions/components/top-reactors.tsx
+++ b/app/reactions/components/top-reactors.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import { useMemo } from "react"
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { SmilePlus } from "lucide-react"
+import type { UserReactionStat } from "@/lib/services/reaction-service"
+import type { Emoji } from "@/lib/services/emoji-service"
+
+interface TopReactorsProps {
+  userStats: UserReactionStat[]
+  emojiData: Emoji[]
+  customEmojiUrls: Map<string, string>
+  onEmojiClick?: (name: string) => void
+}
+
+export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClick }: TopReactorsProps) {
+  // Build user_id → display_name lookup from emoji creators
+  const userNameMap = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const emoji of emojiData) {
+      if (emoji.user_id && emoji.user_display_name && !map.has(emoji.user_id)) {
+        map.set(emoji.user_id, emoji.user_display_name)
+      }
+    }
+    return map
+  }, [emojiData])
+
+  const topReactors = useMemo(() => {
+    return [...userStats]
+      .sort((a, b) => b.reaction_count - a.reaction_count)
+      .slice(0, 10)
+  }, [userStats])
+
+  if (topReactors.length === 0) return null
+
+  const maxCount = topReactors[0].reaction_count
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <SmilePlus className="h-4 w-4" />
+          Top Reactors
+        </CardTitle>
+        <CardDescription className="text-xs">
+          People who reacted to messages the most
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <TooltipProvider delayDuration={200}>
+          <div className="space-y-0.5">
+            {topReactors.map((user, i) => {
+              const displayName = userNameMap.get(user.user_id)
+              const barPct = Math.max(3, (user.reaction_count / maxCount) * 100)
+
+              return (
+                <div
+                  key={user.user_id}
+                  className="flex items-center gap-2 py-1.5 px-1 rounded-md hover:bg-muted/40 transition-colors"
+                >
+                  {/* Rank */}
+                  <span className="text-xs font-semibold text-muted-foreground w-5 text-right tabular-nums shrink-0">
+                    {i + 1}
+                  </span>
+
+                  {/* Name */}
+                  <span className="text-sm font-medium truncate w-28 sm:w-36 shrink-0">
+                    {displayName ? displayName.split(" ")[0] : user.user_id.slice(0, 8)}
+                  </span>
+
+                  {/* Bar */}
+                  <div className="flex-1 min-w-0 hidden sm:block">
+                    <div className="w-full bg-muted/60 rounded-full h-2">
+                      <div
+                        className="h-2 rounded-full bg-primary transition-all"
+                        style={{ width: `${barPct}%` }}
+                      />
+                    </div>
+                  </div>
+
+                  {/* Count */}
+                  <span className="text-xs font-semibold tabular-nums shrink-0 ml-auto sm:ml-0 sm:w-12 text-right">
+                    {user.reaction_count.toLocaleString()}
+                  </span>
+
+                  {/* Top emojis */}
+                  <div className="hidden md:flex items-center gap-0.5 shrink-0">
+                    {user.top_emojis.slice(0, 3).map((name) => {
+                      const url = customEmojiUrls.get(name)
+                      if (!url) return null
+                      return (
+                        <Tooltip key={name}>
+                          <TooltipTrigger asChild>
+                            <img
+                              src={url}
+                              alt={name}
+                              className={`h-4 w-4 object-contain ${onEmojiClick ? "cursor-pointer" : ""}`}
+                              onClick={onEmojiClick ? () => onEmojiClick(name) : undefined}
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent side="top">:{name}:</TooltipContent>
+                        </Tooltip>
+                      )
+                    })}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/top-reactors.tsx
+++ b/app/reactions/components/top-reactors.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Progress } from "@/components/ui/progress"
 import {
   Tooltip,
   TooltipContent,
@@ -10,26 +11,15 @@ import {
 } from "@/components/ui/tooltip"
 import { SmilePlus } from "lucide-react"
 import type { UserReactionStat } from "@/lib/services/reaction-service"
-import type { Emoji } from "@/lib/services/emoji-service"
 
 interface TopReactorsProps {
   userStats: UserReactionStat[]
-  emojiData: Emoji[]
+  userNameMap: Map<string, string>
   customEmojiUrls: Map<string, string>
   onEmojiClick?: (name: string) => void
 }
 
-export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClick }: TopReactorsProps) {
-  // Build user_id → display_name lookup from emoji creators
-  const userNameMap = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const emoji of emojiData) {
-      if (emoji.user_id && emoji.user_display_name && !map.has(emoji.user_id)) {
-        map.set(emoji.user_id, emoji.user_display_name)
-      }
-    }
-    return map
-  }, [emojiData])
+export function TopReactors({ userStats, userNameMap, customEmojiUrls, onEmojiClick }: TopReactorsProps) {
 
   const { topReactors, unnamedCount } = useMemo(() => {
     const sorted = [...userStats].sort((a, b) => b.reaction_count - a.reaction_count)
@@ -84,12 +74,7 @@ export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClic
 
                   {/* Bar */}
                   <div className="flex-1 min-w-0 hidden sm:block">
-                    <div className="w-full bg-muted/60 rounded-full h-2">
-                      <div
-                        className="h-2 rounded-full bg-primary transition-all"
-                        style={{ width: `${barPct}%` }}
-                      />
-                    </div>
+                    <Progress value={barPct} className="h-2 bg-muted/60" />
                   </div>
 
                   {/* Count */}

--- a/app/reactions/components/top-reactors.tsx
+++ b/app/reactions/components/top-reactors.tsx
@@ -31,11 +31,19 @@ export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClic
     return map
   }, [emojiData])
 
-  const topReactors = useMemo(() => {
-    return [...userStats]
-      .sort((a, b) => b.reaction_count - a.reaction_count)
-      .slice(0, 10)
-  }, [userStats])
+  const { topReactors, unnamedCount } = useMemo(() => {
+    const sorted = [...userStats].sort((a, b) => b.reaction_count - a.reaction_count)
+    const named: UserReactionStat[] = []
+    let unnamed = 0
+    for (const user of sorted) {
+      if (userNameMap.has(user.user_id)) {
+        if (named.length < 10) named.push(user)
+      } else {
+        unnamed++
+      }
+    }
+    return { topReactors: named, unnamedCount: unnamed }
+  }, [userStats, userNameMap])
 
   if (topReactors.length === 0) return null
 
@@ -71,7 +79,7 @@ export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClic
 
                   {/* Name */}
                   <span className="text-sm font-medium truncate w-28 sm:w-36 shrink-0">
-                    {displayName ? displayName.split(" ")[0] : user.user_id.slice(0, 8)}
+                    {displayName?.split(" ")[0] ?? user.user_id}
                   </span>
 
                   {/* Bar */}
@@ -113,6 +121,11 @@ export function TopReactors({ userStats, emojiData, customEmojiUrls, onEmojiClic
               )
             })}
           </div>
+          {unnamedCount > 0 && (
+            <p className="text-xs text-muted-foreground mt-3 text-center">
+              + {unnamedCount} more {unnamedCount === 1 ? "person" : "people"} not shown
+            </p>
+          )}
         </TooltipProvider>
       </CardContent>
     </Card>

--- a/app/reactions/components/your-reactions.tsx
+++ b/app/reactions/components/your-reactions.tsx
@@ -28,15 +28,7 @@ function EmojiDisplay({
       />
     )
   }
-  return (
-    <span
-      className="text-xl leading-none"
-      title={`:${name}:`}
-      aria-label={`:${name}:`}
-    >
-      {name}
-    </span>
-  )
+  return null
 }
 
 export function YourReactions({

--- a/app/reactions/components/your-reactions.tsx
+++ b/app/reactions/components/your-reactions.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import type { UserReactionStat } from "@/lib/services/reaction-service"
+
+interface YourReactionsProps {
+  userStats: UserReactionStat[]
+  currentUserId: string | null
+  customEmojiUrls: Map<string, string>
+}
+
+function EmojiDisplay({
+  name,
+  customEmojiUrls,
+}: {
+  name: string
+  customEmojiUrls: Map<string, string>
+}) {
+  const url = customEmojiUrls.get(name)
+  if (url) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={url}
+        alt={`:${name}:`}
+        className="w-8 h-8 object-contain"
+        title={`:${name}:`}
+      />
+    )
+  }
+  return (
+    <span
+      className="text-xl leading-none"
+      title={`:${name}:`}
+      aria-label={`:${name}:`}
+    >
+      {name}
+    </span>
+  )
+}
+
+export function YourReactions({
+  userStats,
+  currentUserId,
+  customEmojiUrls,
+}: YourReactionsProps) {
+  if (!currentUserId) return null
+
+  const myStats = userStats.find((u) => u.user_id === currentUserId)
+  if (!myStats) return null
+
+  const topFive = myStats.top_emojis.slice(0, 5)
+
+  return (
+    <Card>
+      <CardHeader className="pb-4">
+        <CardTitle className="text-base">Your Reactions</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <span>
+            You reacted{" "}
+            <span className="font-semibold text-foreground">
+              {myStats.reaction_count.toLocaleString()}
+            </span>{" "}
+            times across scanned channels.
+          </span>
+        </div>
+        {topFive.length > 0 && (
+          <div>
+            <p className="text-xs text-muted-foreground mb-3 uppercase tracking-wide font-medium">
+              Your top emojis
+            </p>
+            <div className="grid grid-cols-5 gap-3">
+              {topFive.map((name, i) => (
+                <div
+                  key={name}
+                  className="flex flex-col items-center gap-1.5 group"
+                >
+                  <div className="w-12 h-12 rounded-xl bg-muted flex items-center justify-center group-hover:bg-accent transition-colors">
+                    <EmojiDisplay
+                      name={name}
+                      customEmojiUrls={customEmojiUrls}
+                    />
+                  </div>
+                  <span className="text-xs text-muted-foreground text-center truncate w-full leading-tight">
+                    #{i + 1}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/reactions/components/your-reactions.tsx
+++ b/app/reactions/components/your-reactions.tsx
@@ -7,6 +7,7 @@ interface YourReactionsProps {
   userStats: UserReactionStat[]
   currentUserId: string | null
   customEmojiUrls: Map<string, string>
+  onEmojiClick?: (name: string) => void
 }
 
 function EmojiDisplay({
@@ -35,6 +36,7 @@ export function YourReactions({
   userStats,
   currentUserId,
   customEmojiUrls,
+  onEmojiClick,
 }: YourReactionsProps) {
   if (!currentUserId) return null
 
@@ -67,7 +69,8 @@ export function YourReactions({
               {topFive.map((name, i) => (
                 <div
                   key={name}
-                  className="flex flex-col items-center gap-1.5 group"
+                  className={`flex flex-col items-center gap-1.5 group ${onEmojiClick ? "cursor-pointer" : ""}`}
+                  onClick={onEmojiClick ? () => onEmojiClick(name) : undefined}
                 >
                   <div className="w-12 h-12 rounded-xl bg-muted flex items-center justify-center group-hover:bg-accent transition-colors">
                     <EmojiDisplay

--- a/app/reactions/components/your-reactions.tsx
+++ b/app/reactions/components/your-reactions.tsx
@@ -46,7 +46,7 @@ export function YourReactions({
   return (
     <Card>
       <CardHeader className="pb-4">
-        <CardTitle className="text-base">Your Reactions</CardTitle>
+        <CardTitle className="text-base">Your Top Emojis</CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="flex items-center gap-2 text-sm text-muted-foreground">

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -33,7 +33,7 @@ interface ScanProgress {
   reactions_found: number
 }
 
-export function useReactionsState(curlCommand: string | null) {
+export function useReactionsState(curlCommand: string | null, customEmojiNames: Set<string> = new Set()) {
   // Channel state
   const [channels, setChannels] = useState<SlackChannel[]>([])
   const [selectedChannels, setSelectedChannels] = useState<string[]>([])
@@ -87,6 +87,12 @@ export function useReactionsState(curlCommand: string | null) {
       const tokenMatch = curlCommand.match(/token=([^&\s'"]+)/)
       const token = tokenMatch ? tokenMatch[1] : ""
 
+      if (!token) {
+        toast.error("Could not extract auth token from Slack settings")
+        setChannelsLoading(false)
+        return
+      }
+
       const curlRequest = buildCurlRequest(url, {
         token,
         types: "public_channel,private_channel",
@@ -138,6 +144,8 @@ export function useReactionsState(curlCommand: string | null) {
       const tokenMatch = curlCommand?.match(/token=([^&\s'"]+)/)
       const token = tokenMatch ? tokenMatch[1] : ""
 
+      if (!token) return events  // silently return empty — error shown by fetchChannels
+
       const daysBack = dateRange === "7d" ? 7 : 30
       const oldest = Math.floor(Date.now() / 1000) - daysBack * 86400
       let cursor: string | undefined
@@ -157,8 +165,11 @@ export function useReactionsState(curlCommand: string | null) {
         const curlRequest = buildCurlRequest(url, formData)
         if (!curlRequest) break
 
-        // Rate limit: 1.2s between requests
-        await new Promise(resolve => setTimeout(resolve, 1200))
+        // Rate limit: 1.2s between requests (abort-aware)
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, 1200)
+          signal.addEventListener('abort', () => { clearTimeout(t); reject(new DOMException('Aborted', 'AbortError')) }, { once: true })
+        })
 
         const response = await fetch("/api/slack-reactions", {
           method: "POST",
@@ -267,9 +278,9 @@ export function useReactionsState(curlCommand: string | null) {
 
   // Computed data
   const filteredEvents = useMemo(() => {
-    if (emojiFilter === "all") return reactionEvents
-    return reactionEvents
-  }, [reactionEvents, emojiFilter])
+    if (emojiFilter !== "custom") return reactionEvents
+    return reactionEvents.filter(e => customEmojiNames.has(e.emoji_name))
+  }, [reactionEvents, emojiFilter, customEmojiNames])
 
   const stats = useMemo(() => calculateReactionStats(filteredEvents), [filteredEvents])
   const aggregated = useMemo(() => aggregateReactions(filteredEvents), [filteredEvents])

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -6,7 +6,7 @@ import { toast } from "sonner"
 import {
   type ReactionEvent,
   type ReactionScanMeta,
-  aggregateReactions,
+
   getTopReactions,
   getTrendingReactions,
   getUserReactionStats,
@@ -280,28 +280,32 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
   }, [reactionEvents, emojiFilter, customEmojiNames])
 
   const stats = useMemo(() => calculateReactionStats(filteredEvents), [filteredEvents])
-  const aggregated = useMemo(() => aggregateReactions(filteredEvents), [filteredEvents])
-  const topReactions = useMemo(() => getTopReactions(aggregated, 20), [aggregated])
-  const trending = useMemo(() => getTrendingReactions(filteredEvents, 7 * 86400), [filteredEvents])
+  const topReactions = useMemo(() => stats.top_reactions.slice(0, 20), [stats])
+  const trending = useMemo(() => stats.trending, [stats])
   const userStats = useMemo(() => getUserReactionStats(filteredEvents), [filteredEvents])
   const channelBreakdown = useMemo(() => getChannelBreakdown(filteredEvents, 10), [filteredEvents])
 
-  // Timeline data for chart (daily buckets)
+  // Timeline data — single pass bucketing instead of per-day filter
   const timelineData = useMemo(() => {
     if (filteredEvents.length === 0) return []
     const days = dateRange === "7d" ? 7 : 30
     const now = Math.floor(Date.now() / 1000)
-    const buckets: { date: string; count: number }[] = []
 
+    // Single pass: bucket events by day offset
+    const countByDay = new Map<number, number>()
+    for (const e of filteredEvents) {
+      const dayOffset = Math.floor((now - e.timestamp) / 86400)
+      if (dayOffset >= 0 && dayOffset < days) {
+        countByDay.set(dayOffset, (countByDay.get(dayOffset) || 0) + e.count)
+      }
+    }
+
+    const buckets: { date: string; count: number }[] = []
     for (let d = days - 1; d >= 0; d--) {
       const dayStart = now - (d + 1) * 86400
-      const dayEnd = now - d * 86400
-      const dayEvents = filteredEvents.filter(e => e.timestamp >= dayStart && e.timestamp < dayEnd)
-      const count = dayEvents.reduce((sum, e) => sum + e.count, 0)
-      const date = new Date(dayStart * 1000)
       buckets.push({
-        date: date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
-        count,
+        date: new Date(dayStart * 1000).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+        count: countByDay.get(d) || 0,
       })
     }
     return buckets
@@ -327,6 +331,6 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     userStats,
     channelBreakdown,
     timelineData,
-    aggregated,
+    aggregated: stats.top_reactions,
   }
 }

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -14,6 +14,7 @@ import {
   calculateReactionStats,
   reactionStorage,
 } from "@/lib/services/reaction-service"
+import { parseCurlToRequest } from "@/lib/services/emoji-service"
 
 export interface SlackChannel {
   id: string
@@ -52,47 +53,48 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
   const [reactionEvents, setReactionEvents] = useState<ReactionEvent[]>([])
   const abortRef = useRef<AbortController | null>(null)
 
-  // Build curlRequest from stored curl command
+  // Parse the stored curl command once using the existing robust parser
+  const parsedCurl = useMemo(() => {
+    if (!curlCommand) return null
+    try {
+      return parseCurlToRequest(curlCommand)
+    } catch {
+      return null
+    }
+  }, [curlCommand])
+
+  // Extract workspace and token from the parsed curl command
+  const workspace = useMemo(() => {
+    if (!parsedCurl?.url) return ""
+    const match = parsedCurl.url.match(/https:\/\/([^.]+)\.slack\.com/)
+    return match ? match[1] : ""
+  }, [parsedCurl])
+
+  const token = useMemo(() => {
+    return parsedCurl?.formData?.token || ""
+  }, [parsedCurl])
+
+  // Build a curlRequest for a different Slack API endpoint, reusing auth from the stored curl
   const buildCurlRequest = useCallback(
     (url: string, formData?: Record<string, string>) => {
-      if (!curlCommand) return null
-      const headerRegex = /-H\s+'([^:]+):\s*([^']+)'/g
-      const headers: Record<string, string> = {}
-      let match
-      while ((match = headerRegex.exec(curlCommand)) !== null) {
-        headers[match[1]] = match[2]
-      }
-      const headerRegex2 = /-H\s+"([^:]+):\s*([^"]+)"/g
-      while ((match = headerRegex2.exec(curlCommand)) !== null) {
-        headers[match[1]] = match[2]
-      }
-      return { url, headers, formData }
+      if (!parsedCurl) return null
+      return { url, headers: parsedCurl.headers || {}, formData }
     },
-    [curlCommand]
+    [parsedCurl]
   )
 
   // Fetch channel list
   const fetchChannels = useCallback(async () => {
-    if (!curlCommand) return
+    if (!parsedCurl || !workspace) return
     setChannelsLoading(true)
     try {
-      const workspaceMatch = curlCommand.match(/https:\/\/([^.]+)\.slack\.com/)
-      const workspace = workspaceMatch ? workspaceMatch[1] : ""
-      if (!workspace) {
-        toast.error("Could not determine workspace from settings")
-        return
-      }
-
-      const url = `https://${workspace}.slack.com/api/conversations.list`
-      const tokenMatch = curlCommand.match(/token=([^&\s'"]+)/)
-      const token = tokenMatch ? tokenMatch[1] : ""
-
       if (!token) {
         toast.error("Could not extract auth token from Slack settings")
         setChannelsLoading(false)
         return
       }
 
+      const url = `https://${workspace}.slack.com/api/conversations.list`
       const curlRequest = buildCurlRequest(url, {
         token,
         types: "public_channel,private_channel",
@@ -119,7 +121,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     } finally {
       setChannelsLoading(false)
     }
-  }, [curlCommand, buildCurlRequest])
+  }, [parsedCurl, workspace, token, buildCurlRequest])
 
   // Load cached data on mount
   useEffect(() => {
@@ -139,12 +141,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
   const scanChannel = useCallback(
     async (channelId: string, channelName: string, signal: AbortSignal): Promise<ReactionEvent[]> => {
       const events: ReactionEvent[] = []
-      const workspaceMatch = curlCommand?.match(/https:\/\/([^.]+)\.slack\.com/)
-      const workspace = workspaceMatch ? workspaceMatch![1] : ""
-      const tokenMatch = curlCommand?.match(/token=([^&\s'"]+)/)
-      const token = tokenMatch ? tokenMatch[1] : ""
-
-      if (!token) return events  // silently return empty — error shown by fetchChannels
+      if (!workspace || !token) return events
 
       const daysBack = dateRange === "7d" ? 7 : 30
       const oldest = Math.floor(Date.now() / 1000) - daysBack * 86400
@@ -199,7 +196,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
 
       return events
     },
-    [curlCommand, dateRange, buildCurlRequest]
+    [workspace, token, dateRange, buildCurlRequest]
   )
 
   // Start scan across selected channels
@@ -208,7 +205,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
       toast.error("Select at least one channel to scan")
       return
     }
-    if (!curlCommand) {
+    if (!token || !workspace) {
       toast.error("Connect to Slack in Settings first")
       return
     }
@@ -268,7 +265,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
       await reactionStorage.saveReactions(allEvents, meta)
       toast.success(`Scan complete! Found ${allEvents.length} reactions.`)
     }
-  }, [selectedChannels, curlCommand, channels, dateRange, scanChannel])
+  }, [selectedChannels, token, channels, dateRange, scanChannel])
 
   // Cancel scan
   const cancelScan = useCallback(() => {

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -31,6 +31,7 @@ interface ScanProgress {
   channels_done: number
   channels_total: number
   reactions_found: number
+  scanned_channels: string[]
 }
 
 export function useReactionsState(curlCommand: string | null, customEmojiNames: Set<string> = new Set()) {
@@ -48,6 +49,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     channels_done: 0,
     channels_total: 0,
     reactions_found: 0,
+    scanned_channels: [],
   })
   const [reactionEvents, setReactionEvents] = useState<ReactionEvent[]>([])
   const abortRef = useRef<AbortController | null>(null)
@@ -129,7 +131,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
         setReactionEvents(cached.events)
         const channelIds = cached.meta?.channel_ids ?? []
         setSelectedChannels(channelIds)
-        setScanProgress({ status: "complete", current_channel: "", channels_done: channelIds.length, channels_total: channelIds.length, reactions_found: cached.events.length })
+        setScanProgress({ status: "complete", current_channel: "", channels_done: channelIds.length, channels_total: channelIds.length, reactions_found: cached.events.length, scanned_channels: [] })
       }
     }
     loadCache()
@@ -226,6 +228,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
       channels_done: 0,
       channels_total: selectedChannels.length,
       reactions_found: 0,
+      scanned_channels: [],
     })
     setReactionEvents([])
 
@@ -252,6 +255,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
           ...prev,
           channels_done: i + 1,
           reactions_found: allEvents.length,
+          scanned_channels: [...prev.scanned_channels, channelName],
         }))
       } catch (error) {
         if ((error as Error).name === "AbortError") break

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -6,9 +6,6 @@ import { toast } from "sonner"
 import {
   type ReactionEvent,
   type ReactionScanMeta,
-
-  getTopReactions,
-  getTrendingReactions,
   getUserReactionStats,
   getChannelBreakdown,
   calculateReactionStats,
@@ -53,7 +50,6 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
   const [reactionEvents, setReactionEvents] = useState<ReactionEvent[]>([])
   const abortRef = useRef<AbortController | null>(null)
 
-  // Parse the stored curl command once using the existing robust parser
   const parsedCurl = useMemo(() => {
     if (!curlCommand) return null
     try {
@@ -288,7 +284,6 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
 
   const stats = useMemo(() => calculateReactionStats(filteredEvents), [filteredEvents])
   const topReactions = useMemo(() => stats.top_reactions.slice(0, 20), [stats])
-  const trending = useMemo(() => stats.trending, [stats])
   const userStats = useMemo(() => getUserReactionStats(filteredEvents), [filteredEvents])
   const channelBreakdown = useMemo(() => getChannelBreakdown(filteredEvents, 10), [filteredEvents])
 
@@ -334,10 +329,8 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     reactionEvents: filteredEvents,
     stats,
     topReactions,
-    trending,
     userStats,
     channelBreakdown,
     timelineData,
-    aggregated: stats.top_reactions,
   }
 }

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -123,7 +123,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     }
   }, [parsedCurl, workspace, token, buildCurlRequest])
 
-  // Load cached data on mount
+  // Load cached data on mount and fetch channel names
   useEffect(() => {
     async function loadCache() {
       const cached = await reactionStorage.loadReactions()
@@ -136,6 +136,13 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
     }
     loadCache()
   }, [])
+
+  // Fetch channel names whenever we have auth but no channel list loaded yet
+  useEffect(() => {
+    if (token && workspace && channels.length === 0) {
+      fetchChannels()
+    }
+  }, [token, workspace, channels.length, fetchChannels])
 
   // Scan a single channel for reactions
   const scanChannel = useCallback(

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -20,8 +20,10 @@ export interface SlackChannel {
   num_members: number
 }
 
-export type DateRange = "7d" | "30d"
+export type DateRange = "24h" | "7d" | "30d" | "90d"
 export type EmojiFilter = "all" | "custom"
+
+const DATE_RANGE_DAYS: Record<DateRange, number> = { "24h": 1, "7d": 7, "30d": 30, "90d": 90 }
 
 interface ScanProgress {
   status: "idle" | "scanning" | "complete" | "error"
@@ -39,7 +41,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
 
   // Scan state
   const [dateRange, setDateRange] = useState<DateRange>("7d")
-  const [emojiFilter, setEmojiFilter] = useState<EmojiFilter>("all")
+  const [emojiFilter, setEmojiFilter] = useState<EmojiFilter>("custom")
   const [scanProgress, setScanProgress] = useState<ScanProgress>({
     status: "idle",
     current_channel: "",
@@ -146,7 +148,7 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
       const events: ReactionEvent[] = []
       if (!workspace || !token) return events
 
-      const daysBack = dateRange === "7d" ? 7 : 30
+      const daysBack = DATE_RANGE_DAYS[dateRange]
       const oldest = Math.floor(Date.now() / 1000) - daysBack * 86400
       let cursor: string | undefined
 
@@ -287,28 +289,29 @@ export function useReactionsState(curlCommand: string | null, customEmojiNames: 
   const userStats = useMemo(() => getUserReactionStats(filteredEvents), [filteredEvents])
   const channelBreakdown = useMemo(() => getChannelBreakdown(filteredEvents, 10), [filteredEvents])
 
-  // Timeline data — single pass bucketing instead of per-day filter
   const timelineData = useMemo(() => {
     if (filteredEvents.length === 0) return []
-    const days = dateRange === "7d" ? 7 : 30
     const now = Math.floor(Date.now() / 1000)
+    const isHourly = dateRange === "24h"
+    const bucketCount = isHourly ? 24 : DATE_RANGE_DAYS[dateRange]
+    const bucketSize = isHourly ? 3600 : 86400
 
-    // Single pass: bucket events by day offset
-    const countByDay = new Map<number, number>()
+    const countByBucket = new Map<number, number>()
     for (const e of filteredEvents) {
-      const dayOffset = Math.floor((now - e.timestamp) / 86400)
-      if (dayOffset >= 0 && dayOffset < days) {
-        countByDay.set(dayOffset, (countByDay.get(dayOffset) || 0) + e.count)
+      const offset = Math.floor((now - e.timestamp) / bucketSize)
+      if (offset >= 0 && offset < bucketCount) {
+        countByBucket.set(offset, (countByBucket.get(offset) || 0) + e.count)
       }
     }
 
     const buckets: { date: string; count: number }[] = []
-    for (let d = days - 1; d >= 0; d--) {
-      const dayStart = now - (d + 1) * 86400
-      buckets.push({
-        date: new Date(dayStart * 1000).toLocaleDateString("en-US", { month: "short", day: "numeric" }),
-        count: countByDay.get(d) || 0,
-      })
+    for (let i = bucketCount - 1; i >= 0; i--) {
+      const ts = now - (i + 1) * bucketSize
+      const d = new Date(ts * 1000)
+      const label = isHourly
+        ? d.toLocaleTimeString("en-US", { hour: "numeric" })
+        : d.toLocaleDateString("en-US", { month: "short", day: "numeric" })
+      buckets.push({ date: label, count: countByBucket.get(i) || 0 })
     }
     return buckets
   }, [filteredEvents, dateRange])

--- a/app/reactions/hooks/use-reactions-state.ts
+++ b/app/reactions/hooks/use-reactions-state.ts
@@ -1,0 +1,324 @@
+// app/reactions/hooks/use-reactions-state.ts
+"use client"
+
+import { useState, useCallback, useMemo, useRef, useEffect } from "react"
+import { toast } from "sonner"
+import {
+  type ReactionEvent,
+  type ReactionScanMeta,
+  aggregateReactions,
+  getTopReactions,
+  getTrendingReactions,
+  getUserReactionStats,
+  getChannelBreakdown,
+  calculateReactionStats,
+  reactionStorage,
+} from "@/lib/services/reaction-service"
+
+export interface SlackChannel {
+  id: string
+  name: string
+  is_private: boolean
+  num_members: number
+}
+
+export type DateRange = "7d" | "30d"
+export type EmojiFilter = "all" | "custom"
+
+interface ScanProgress {
+  status: "idle" | "scanning" | "complete" | "error"
+  current_channel: string
+  channels_done: number
+  channels_total: number
+  reactions_found: number
+}
+
+export function useReactionsState(curlCommand: string | null) {
+  // Channel state
+  const [channels, setChannels] = useState<SlackChannel[]>([])
+  const [selectedChannels, setSelectedChannels] = useState<string[]>([])
+  const [channelsLoading, setChannelsLoading] = useState(false)
+
+  // Scan state
+  const [dateRange, setDateRange] = useState<DateRange>("7d")
+  const [emojiFilter, setEmojiFilter] = useState<EmojiFilter>("all")
+  const [scanProgress, setScanProgress] = useState<ScanProgress>({
+    status: "idle",
+    current_channel: "",
+    channels_done: 0,
+    channels_total: 0,
+    reactions_found: 0,
+  })
+  const [reactionEvents, setReactionEvents] = useState<ReactionEvent[]>([])
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Build curlRequest from stored curl command
+  const buildCurlRequest = useCallback(
+    (url: string, formData?: Record<string, string>) => {
+      if (!curlCommand) return null
+      const headerRegex = /-H\s+'([^:]+):\s*([^']+)'/g
+      const headers: Record<string, string> = {}
+      let match
+      while ((match = headerRegex.exec(curlCommand)) !== null) {
+        headers[match[1]] = match[2]
+      }
+      const headerRegex2 = /-H\s+"([^:]+):\s*([^"]+)"/g
+      while ((match = headerRegex2.exec(curlCommand)) !== null) {
+        headers[match[1]] = match[2]
+      }
+      return { url, headers, formData }
+    },
+    [curlCommand]
+  )
+
+  // Fetch channel list
+  const fetchChannels = useCallback(async () => {
+    if (!curlCommand) return
+    setChannelsLoading(true)
+    try {
+      const workspaceMatch = curlCommand.match(/https:\/\/([^.]+)\.slack\.com/)
+      const workspace = workspaceMatch ? workspaceMatch[1] : ""
+      if (!workspace) {
+        toast.error("Could not determine workspace from settings")
+        return
+      }
+
+      const url = `https://${workspace}.slack.com/api/conversations.list`
+      const tokenMatch = curlCommand.match(/token=([^&\s'"]+)/)
+      const token = tokenMatch ? tokenMatch[1] : ""
+
+      const curlRequest = buildCurlRequest(url, {
+        token,
+        types: "public_channel,private_channel",
+        exclude_archived: "true",
+        limit: "200",
+      })
+      if (!curlRequest) return
+
+      const response = await fetch("/api/slack-reactions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ curlRequest }),
+      })
+
+      const data = await response.json()
+      if (data.ok && data.channels) {
+        setChannels(data.channels.sort((a: SlackChannel, b: SlackChannel) => b.num_members - a.num_members))
+      } else {
+        toast.error(data.error || "Failed to fetch channels")
+      }
+    } catch (error) {
+      console.error("Failed to fetch channels:", error)
+      toast.error("Failed to fetch channels")
+    } finally {
+      setChannelsLoading(false)
+    }
+  }, [curlCommand, buildCurlRequest])
+
+  // Load cached data on mount
+  useEffect(() => {
+    async function loadCache() {
+      const cached = await reactionStorage.loadReactions()
+      if (cached) {
+        setReactionEvents(cached.events)
+        const channelIds = cached.meta?.channel_ids ?? []
+        setSelectedChannels(channelIds)
+        setScanProgress({ status: "complete", current_channel: "", channels_done: channelIds.length, channels_total: channelIds.length, reactions_found: cached.events.length })
+      }
+    }
+    loadCache()
+  }, [])
+
+  // Scan a single channel for reactions
+  const scanChannel = useCallback(
+    async (channelId: string, channelName: string, signal: AbortSignal): Promise<ReactionEvent[]> => {
+      const events: ReactionEvent[] = []
+      const workspaceMatch = curlCommand?.match(/https:\/\/([^.]+)\.slack\.com/)
+      const workspace = workspaceMatch ? workspaceMatch![1] : ""
+      const tokenMatch = curlCommand?.match(/token=([^&\s'"]+)/)
+      const token = tokenMatch ? tokenMatch[1] : ""
+
+      const daysBack = dateRange === "7d" ? 7 : 30
+      const oldest = Math.floor(Date.now() / 1000) - daysBack * 86400
+      let cursor: string | undefined
+
+      do {
+        if (signal.aborted) break
+
+        const url = `https://${workspace}.slack.com/api/conversations.history`
+        const formData: Record<string, string> = {
+          token,
+          channel: channelId,
+          oldest: String(oldest),
+          limit: "200",
+        }
+        if (cursor) formData.cursor = cursor
+
+        const curlRequest = buildCurlRequest(url, formData)
+        if (!curlRequest) break
+
+        // Rate limit: 1.2s between requests
+        await new Promise(resolve => setTimeout(resolve, 1200))
+
+        const response = await fetch("/api/slack-reactions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ curlRequest }),
+          signal,
+        })
+
+        const data = await response.json()
+        if (!data.ok) {
+          console.error(`Scan error for #${channelName}:`, data.error)
+          break
+        }
+
+        for (const reaction of data.reactions || []) {
+          events.push({
+            emoji_name: reaction.emoji_name,
+            count: reaction.count,
+            user_ids: reaction.users,
+            channel_id: channelId,
+            timestamp: reaction.timestamp,
+          })
+        }
+
+        cursor = data.has_more ? data.response_metadata?.next_cursor : undefined
+      } while (cursor)
+
+      return events
+    },
+    [curlCommand, dateRange, buildCurlRequest]
+  )
+
+  // Start scan across selected channels
+  const startScan = useCallback(async () => {
+    if (selectedChannels.length === 0) {
+      toast.error("Select at least one channel to scan")
+      return
+    }
+    if (!curlCommand) {
+      toast.error("Connect to Slack in Settings first")
+      return
+    }
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    const allEvents: ReactionEvent[] = []
+    setScanProgress({
+      status: "scanning",
+      current_channel: "",
+      channels_done: 0,
+      channels_total: selectedChannels.length,
+      reactions_found: 0,
+    })
+    setReactionEvents([])
+
+    const channelNames = new Map(channels.map(c => [c.id, c.name]))
+
+    for (let i = 0; i < selectedChannels.length; i++) {
+      if (controller.signal.aborted) break
+
+      const channelId = selectedChannels[i]
+      const channelName = channelNames.get(channelId) || channelId
+
+      setScanProgress(prev => ({
+        ...prev,
+        current_channel: channelName,
+        channels_done: i,
+      }))
+
+      try {
+        const channelEvents = await scanChannel(channelId, channelName, controller.signal)
+        allEvents.push(...channelEvents)
+
+        setReactionEvents([...allEvents])
+        setScanProgress(prev => ({
+          ...prev,
+          channels_done: i + 1,
+          reactions_found: allEvents.length,
+        }))
+      } catch (error) {
+        if ((error as Error).name === "AbortError") break
+        console.error(`Error scanning #${channelName}:`, error)
+      }
+    }
+
+    if (!controller.signal.aborted) {
+      setScanProgress(prev => ({ ...prev, status: "complete" }))
+
+      const meta: ReactionScanMeta = {
+        channel_ids: selectedChannels,
+        scanned_at: Date.now(),
+        event_count: allEvents.length,
+      }
+      await reactionStorage.saveReactions(allEvents, meta)
+      toast.success(`Scan complete! Found ${allEvents.length} reactions.`)
+    }
+  }, [selectedChannels, curlCommand, channels, dateRange, scanChannel])
+
+  // Cancel scan
+  const cancelScan = useCallback(() => {
+    abortRef.current?.abort()
+    setScanProgress(prev => ({ ...prev, status: "idle" }))
+  }, [])
+
+  // Computed data
+  const filteredEvents = useMemo(() => {
+    if (emojiFilter === "all") return reactionEvents
+    return reactionEvents
+  }, [reactionEvents, emojiFilter])
+
+  const stats = useMemo(() => calculateReactionStats(filteredEvents), [filteredEvents])
+  const aggregated = useMemo(() => aggregateReactions(filteredEvents), [filteredEvents])
+  const topReactions = useMemo(() => getTopReactions(aggregated, 20), [aggregated])
+  const trending = useMemo(() => getTrendingReactions(filteredEvents, 7 * 86400), [filteredEvents])
+  const userStats = useMemo(() => getUserReactionStats(filteredEvents), [filteredEvents])
+  const channelBreakdown = useMemo(() => getChannelBreakdown(filteredEvents, 10), [filteredEvents])
+
+  // Timeline data for chart (daily buckets)
+  const timelineData = useMemo(() => {
+    if (filteredEvents.length === 0) return []
+    const days = dateRange === "7d" ? 7 : 30
+    const now = Math.floor(Date.now() / 1000)
+    const buckets: { date: string; count: number }[] = []
+
+    for (let d = days - 1; d >= 0; d--) {
+      const dayStart = now - (d + 1) * 86400
+      const dayEnd = now - d * 86400
+      const dayEvents = filteredEvents.filter(e => e.timestamp >= dayStart && e.timestamp < dayEnd)
+      const count = dayEvents.reduce((sum, e) => sum + e.count, 0)
+      const date = new Date(dayStart * 1000)
+      buckets.push({
+        date: date.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+        count,
+      })
+    }
+    return buckets
+  }, [filteredEvents, dateRange])
+
+  return {
+    channels,
+    selectedChannels,
+    setSelectedChannels,
+    channelsLoading,
+    fetchChannels,
+    dateRange,
+    setDateRange,
+    emojiFilter,
+    setEmojiFilter,
+    scanProgress,
+    startScan,
+    cancelScan,
+    reactionEvents: filteredEvents,
+    stats,
+    topReactions,
+    trending,
+    userStats,
+    channelBreakdown,
+    timelineData,
+    aggregated,
+  }
+}

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -88,6 +88,7 @@ export default function ReactionsPage() {
         channelsTotal={state.scanProgress.channels_total}
         reactionsFound={state.scanProgress.reactions_found}
         onCancel={state.cancelScan}
+        scannedChannels={state.scanProgress.scanned_channels}
       />
 
       {!hasData && (

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -355,6 +355,7 @@ export default function ReactionsPage() {
               breakdown={state.channelBreakdown}
               channels={state.channels}
               customEmojiUrls={customEmojiUrls}
+              emojiData={emojiData}
               onEmojiClick={handleEmojiClick}
             />
           </div>

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -10,6 +10,8 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { InfoDrawerResponsive } from "@/components/info-drawer-responsive"
+import EmojiOverlay from "@/components/emoji-overlay"
+import type { Emoji } from "@/lib/services/emoji-service"
 import { useReactionsState } from "./hooks/use-reactions-state"
 import { ChannelPicker } from "./components/channel-picker"
 import { ScanProgress } from "./components/scan-progress"
@@ -20,6 +22,7 @@ import { YourReactions } from "./components/your-reactions"
 import { ChannelBreakdown } from "./components/channel-breakdown"
 import { ShareCardGenerator } from "./components/share-card-generator"
 import { TopCreators } from "./components/top-creators"
+import { TopReactors } from "./components/top-reactors"
 
 export default function ReactionsPage() {
   const isClient = useIsClient()
@@ -46,6 +49,22 @@ export default function ReactionsPage() {
     }
     return { customEmojiNames: names, customEmojiUrls: urls }
   }, [emojiData])
+
+  // Lookup map for opening emoji overlay by name
+  const emojiByName = useMemo(() => {
+    const map = new Map<string, Emoji>()
+    for (const emoji of emojiData) {
+      if (!emoji.is_alias) map.set(emoji.name, emoji)
+    }
+    return map
+  }, [emojiData])
+
+  const [selectedEmoji, setSelectedEmoji] = useState<Emoji | null>(null)
+
+  const handleEmojiClick = (name: string) => {
+    const emoji = emojiByName.get(name)
+    if (emoji) setSelectedEmoji(emoji)
+  }
 
   const analytics = useAnalytics()
   const state = useReactionsState(curlCommand, customEmojiNames)
@@ -269,31 +288,38 @@ export default function ReactionsPage() {
         <>
           {/* Stats Cards */}
           <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-100 ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
-            <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} />
+            <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} onEmojiClick={handleEmojiClick} />
           </div>
 
-          {/* Top Reactions + Top Creators (2/3 + 1/3 on desktop) */}
+          {/* Top Reactions */}
           <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-150 ${pageVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-3 scale-[0.98]"}`}>
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6">
-              <div className="lg:col-span-2">
-                <TopReactionsChart
-                  topReactions={state.topReactions}
-                  emojiFilter={state.emojiFilter}
-                  setEmojiFilter={(filter) => {
-                    analytics.trackReactionsFilterChanged(filter)
-                    state.setEmojiFilter(filter)
-                  }}
-                  customEmojiUrls={customEmojiUrls}
-                  emojiData={emojiData}
-                />
-              </div>
-              <div className="lg:col-span-1">
-                <TopCreators
-                  topReactions={state.topReactions}
-                  emojiData={emojiData}
-                  customEmojiUrls={customEmojiUrls}
-                />
-              </div>
+            <TopReactionsChart
+              topReactions={state.topReactions}
+              emojiFilter={state.emojiFilter}
+              setEmojiFilter={(filter) => {
+                analytics.trackReactionsFilterChanged(filter)
+                state.setEmojiFilter(filter)
+              }}
+              customEmojiUrls={customEmojiUrls}
+              emojiData={emojiData}
+              onEmojiClick={handleEmojiClick}
+            />
+          </div>
+
+          {/* Top Reactors + Top Creators (side by side on desktop) */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-200 ${pageVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-3 scale-[0.98]"}`}>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
+              <TopReactors
+                userStats={state.userStats}
+                emojiData={emojiData}
+                customEmojiUrls={customEmojiUrls}
+                onEmojiClick={handleEmojiClick}
+              />
+              <TopCreators
+                topReactions={state.topReactions}
+                emojiData={emojiData}
+                customEmojiUrls={customEmojiUrls}
+              />
             </div>
           </div>
 
@@ -309,6 +335,7 @@ export default function ReactionsPage() {
                 userStats={state.userStats}
                 currentUserId={currentUserId}
                 customEmojiUrls={customEmojiUrls}
+                onEmojiClick={handleEmojiClick}
               />
               <ShareCardGenerator
                 stats={state.stats}
@@ -328,10 +355,16 @@ export default function ReactionsPage() {
               breakdown={state.channelBreakdown}
               channels={state.channels}
               customEmojiUrls={customEmojiUrls}
+              onEmojiClick={handleEmojiClick}
             />
           </div>
         </>
       )}
+
+      <EmojiOverlay
+        emoji={selectedEmoji}
+        onClose={() => setSelectedEmoji(null)}
+      />
     </div>
   )
 }

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -25,7 +25,15 @@ function ReactionsPage() {
   const currentUserId =
     isClient ? (typeof window !== "undefined" ? localStorage.getItem("slackUserId") : null) : null
 
-  const state = useReactionsState(curlCommand)
+  const customEmojiNames = useMemo(() => {
+    const names = new Set<string>()
+    for (const emoji of emojiData) {
+      if (emoji.url && !emoji.is_alias) names.add(emoji.name)
+    }
+    return names
+  }, [emojiData])
+
+  const state = useReactionsState(curlCommand, customEmojiNames)
 
   const customEmojiUrls = useMemo(() => {
     const map = new Map<string, string>()

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -14,6 +14,7 @@ import { ReactionTimeline } from "./components/reaction-timeline"
 import { YourReactions } from "./components/your-reactions"
 import { ChannelBreakdown } from "./components/channel-breakdown"
 import { ShareCardGenerator } from "./components/share-card-generator"
+import { TopCreators } from "./components/top-creators"
 
 function ReactionsPage() {
   const isClient = useIsClient()
@@ -115,6 +116,12 @@ function ReactionsPage() {
             topReactions={state.topReactions}
             emojiFilter={state.emojiFilter}
             setEmojiFilter={state.setEmojiFilter}
+            customEmojiUrls={customEmojiUrls}
+            emojiData={emojiData}
+          />
+          <TopCreators
+            topReactions={state.topReactions}
+            emojiData={emojiData}
             customEmojiUrls={customEmojiUrls}
           />
           <ReactionTimeline data={state.timelineData} />

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useMemo } from "react"
+import { useMemo, useEffect, useRef } from "react"
 import { BarChart3 } from "lucide-react"
 import { useEmojiData } from "@/lib/hooks/use-emoji-data"
 import { useIsClient } from "@/hooks/use-is-client"
+import { useAnalytics } from "@/lib/analytics"
 import { Skeleton } from "@/components/ui/skeleton"
 import { useReactionsState } from "./hooks/use-reactions-state"
 import { ChannelPicker } from "./components/channel-picker"
@@ -36,9 +37,23 @@ export default function ReactionsPage() {
     return { customEmojiNames: names, customEmojiUrls: urls }
   }, [emojiData])
 
+  const analytics = useAnalytics()
   const state = useReactionsState(curlCommand, customEmojiNames)
 
   const hasData = state.reactionEvents.length > 0
+
+  // Track scan completion
+  const prevStatusRef = useRef(state.scanProgress.status)
+  useEffect(() => {
+    if (prevStatusRef.current === "scanning" && state.scanProgress.status === "complete") {
+      analytics.trackReactionsScanCompleted(
+        state.scanProgress.channels_done,
+        state.scanProgress.reactions_found,
+        state.dateRange
+      )
+    }
+    prevStatusRef.current = state.scanProgress.status
+  }, [state.scanProgress.status, state.scanProgress.channels_done, state.scanProgress.reactions_found, state.dateRange, analytics])
 
   const channelNames = useMemo(
     () => state.selectedChannels.map(id => state.channels.find(c => c.id === id)?.name ?? id),
@@ -76,8 +91,14 @@ export default function ReactionsPage() {
         channelsLoading={state.channelsLoading}
         fetchChannels={state.fetchChannels}
         dateRange={state.dateRange}
-        setDateRange={state.setDateRange}
-        onScan={state.startScan}
+        setDateRange={(range) => {
+          analytics.trackReactionsDateRangeChanged(range)
+          state.setDateRange(range)
+        }}
+        onScan={() => {
+          analytics.trackReactionsScanStarted(state.selectedChannels.length, state.dateRange)
+          state.startScan()
+        }}
         scanStatus={state.scanProgress.status}
       />
 
@@ -108,7 +129,10 @@ export default function ReactionsPage() {
           <TopReactionsChart
             topReactions={state.topReactions}
             emojiFilter={state.emojiFilter}
-            setEmojiFilter={state.setEmojiFilter}
+            setEmojiFilter={(filter) => {
+              analytics.trackReactionsFilterChanged(filter)
+              state.setEmojiFilter(filter)
+            }}
             customEmojiUrls={customEmojiUrls}
             emojiData={emojiData}
           />
@@ -134,6 +158,8 @@ export default function ReactionsPage() {
             customEmojiUrls={customEmojiUrls}
             channelNames={channelNames}
             dateRange={state.dateRange}
+            onDownload={analytics.trackReactionsShareCardDownloaded}
+            onCopy={analytics.trackReactionsShareCardCopied}
           />
         </>
       )}

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -40,6 +40,11 @@ export default function ReactionsPage() {
 
   const hasData = state.reactionEvents.length > 0
 
+  const channelNames = useMemo(
+    () => state.selectedChannels.map(id => state.channels.find(c => c.id === id)?.name ?? id),
+    [state.selectedChannels, state.channels]
+  )
+
   if (!isClient) {
     return (
       <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
@@ -126,9 +131,7 @@ export default function ReactionsPage() {
             stats={state.stats}
             topReactions={state.topReactions}
             customEmojiUrls={customEmojiUrls}
-            channelNames={state.selectedChannels.map(
-              id => state.channels.find(c => c.id === id)?.name ?? id
-            )}
+            channelNames={channelNames}
             dateRange={state.dateRange}
           />
         </>

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
-import { useMemo, useEffect, useRef } from "react"
-import { BarChart3 } from "lucide-react"
+import { useMemo, useEffect, useRef, useState } from "react"
+import { Activity, Hash, Settings } from "lucide-react"
+import Link from "next/link"
 import { useEmojiData } from "@/lib/hooks/use-emoji-data"
 import { useIsClient } from "@/hooks/use-is-client"
 import { useAnalytics } from "@/lib/analytics"
 import { Skeleton } from "@/components/ui/skeleton"
+import { Card, CardContent } from "@/components/ui/card"
 import { useReactionsState } from "./hooks/use-reactions-state"
 import { ChannelPicker } from "./components/channel-picker"
 import { ScanProgress } from "./components/scan-progress"
@@ -20,6 +22,12 @@ import { TopCreators } from "./components/top-creators"
 export default function ReactionsPage() {
   const isClient = useIsClient()
   const { emojiData, hasRealData } = useEmojiData()
+  const [pageVisible, setPageVisible] = useState(false)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setPageVisible(true), 100)
+    return () => clearTimeout(timer)
+  }, [])
 
   const curlCommand = isClient ? localStorage.getItem("slackCurlCommand") : null
   const currentUserId = isClient ? localStorage.getItem("slackUserId") : null
@@ -62,105 +70,189 @@ export default function ReactionsPage() {
 
   if (!isClient) {
     return (
-      <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-16 w-full" />
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full" />
-          ))}
+      <div className="flex flex-col gap-6 md:gap-8 w-full pb-8">
+        <div className="px-3 sm:px-4 lg:px-6 pt-4 md:pt-6">
+          <Skeleton className="h-8 w-48 mb-2" />
+          <Skeleton className="h-4 w-72" />
+          <Skeleton className="h-10 w-full mt-4" />
         </div>
-        <Skeleton className="h-64 w-full" />
+        <div className="px-3 sm:px-4 lg:px-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <Skeleton key={i} className="h-24 w-full rounded-xl" />
+            ))}
+          </div>
+        </div>
+        <div className="px-3 sm:px-4 lg:px-6">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6">
+            <Skeleton className="h-[400px] w-full rounded-xl lg:col-span-2" />
+            <Skeleton className="h-[400px] w-full rounded-xl" />
+          </div>
+        </div>
+        <div className="px-3 sm:px-4 lg:px-6">
+          <Skeleton className="h-[200px] w-full rounded-xl" />
+        </div>
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
-      <div>
-        <h1 className="text-2xl font-bold tracking-tight">Reactions Dashboard</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          Scan Slack channels to explore emoji reaction activity.
-        </p>
+    <div className="flex flex-col gap-6 md:gap-8 w-full pb-8">
+      {/* Header + Channel Picker */}
+      <div className={`px-3 sm:px-4 lg:px-6 pt-4 md:pt-6 transition-all duration-500 ease-out ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
+        <div className="flex flex-col gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Usage</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              See how your workspace&apos;s emojis are being used across Slack.
+            </p>
+          </div>
+
+          <ChannelPicker
+            channels={state.channels}
+            selectedChannels={state.selectedChannels}
+            setSelectedChannels={state.setSelectedChannels}
+            channelsLoading={state.channelsLoading}
+            fetchChannels={state.fetchChannels}
+            dateRange={state.dateRange}
+            setDateRange={(range) => {
+              analytics.trackReactionsDateRangeChanged(range)
+              state.setDateRange(range)
+            }}
+            onScan={() => {
+              analytics.trackReactionsScanStarted(state.selectedChannels.length, state.dateRange)
+              state.startScan()
+            }}
+            scanStatus={state.scanProgress.status}
+          />
+        </div>
       </div>
 
-      <ChannelPicker
-        channels={state.channels}
-        selectedChannels={state.selectedChannels}
-        setSelectedChannels={state.setSelectedChannels}
-        channelsLoading={state.channelsLoading}
-        fetchChannels={state.fetchChannels}
-        dateRange={state.dateRange}
-        setDateRange={(range) => {
-          analytics.trackReactionsDateRangeChanged(range)
-          state.setDateRange(range)
-        }}
-        onScan={() => {
-          analytics.trackReactionsScanStarted(state.selectedChannels.length, state.dateRange)
-          state.startScan()
-        }}
-        scanStatus={state.scanProgress.status}
-      />
+      {/* Scan Progress */}
+      <div className="px-3 sm:px-4 lg:px-6">
+        <ScanProgress
+          status={state.scanProgress.status}
+          currentChannel={state.scanProgress.current_channel}
+          channelsDone={state.scanProgress.channels_done}
+          channelsTotal={state.scanProgress.channels_total}
+          reactionsFound={state.scanProgress.reactions_found}
+          onCancel={state.cancelScan}
+          scannedChannels={state.scanProgress.scanned_channels}
+        />
+      </div>
 
-      <ScanProgress
-        status={state.scanProgress.status}
-        currentChannel={state.scanProgress.current_channel}
-        channelsDone={state.scanProgress.channels_done}
-        channelsTotal={state.scanProgress.channels_total}
-        reactionsFound={state.scanProgress.reactions_found}
-        onCancel={state.cancelScan}
-        scannedChannels={state.scanProgress.scanned_channels}
-      />
-
-      {!hasData && (
-        <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
-          <BarChart3 className="h-12 w-12 opacity-30" />
-          <p className="text-sm">
-            {!hasRealData
-              ? "Connect to Slack in Settings to get started."
-              : "Select channels above and run a scan to see reaction data."}
-          </p>
+      {/* Empty State */}
+      {!hasData && state.scanProgress.status !== "scanning" && (
+        <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-100 ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
+          <Card className="border-dashed">
+            <CardContent className="flex flex-col items-center justify-center gap-4 py-16">
+              <div className="rounded-full bg-muted p-4">
+                <Activity className="h-8 w-8 text-muted-foreground" />
+              </div>
+              {!hasRealData ? (
+                <div className="text-center space-y-2">
+                  <p className="text-sm font-medium">Connect to Slack to get started</p>
+                  <p className="text-sm text-muted-foreground max-w-sm">
+                    You&apos;ll need to connect your Slack workspace before scanning emoji usage.
+                  </p>
+                  <Link
+                    href="/settings"
+                    className="inline-flex items-center gap-1.5 mt-2 rounded-full border border-border bg-card px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-foreground/20 transition-colors"
+                  >
+                    <Settings className="h-3.5 w-3.5" />
+                    Go to Settings
+                  </Link>
+                </div>
+              ) : (
+                <div className="text-center space-y-3">
+                  <p className="text-sm font-medium">Ready to scan</p>
+                  <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center h-5 w-5 rounded-full bg-primary/10 text-primary text-xs font-bold">1</span>
+                      <span>Select channels above</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center h-5 w-5 rounded-full bg-primary/10 text-primary text-xs font-bold">2</span>
+                      <span>Pick a date range</span>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className="flex items-center justify-center h-5 w-5 rounded-full bg-primary/10 text-primary text-xs font-bold">3</span>
+                      <span>Click <strong>Scan Channels</strong> to see usage data</span>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
         </div>
       )}
 
+      {/* Data Sections */}
       {hasData && (
         <>
-          <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} />
-          <TopReactionsChart
-            topReactions={state.topReactions}
-            emojiFilter={state.emojiFilter}
-            setEmojiFilter={(filter) => {
-              analytics.trackReactionsFilterChanged(filter)
-              state.setEmojiFilter(filter)
-            }}
-            customEmojiUrls={customEmojiUrls}
-            emojiData={emojiData}
-          />
-          <TopCreators
-            topReactions={state.topReactions}
-            emojiData={emojiData}
-            customEmojiUrls={customEmojiUrls}
-          />
-          <ReactionTimeline data={state.timelineData} />
-          <YourReactions
-            userStats={state.userStats}
-            currentUserId={currentUserId}
-            customEmojiUrls={customEmojiUrls}
-          />
-          <ChannelBreakdown
-            breakdown={state.channelBreakdown}
-            channels={state.channels}
-            customEmojiUrls={customEmojiUrls}
-          />
-          <ShareCardGenerator
-            stats={state.stats}
-            topReactions={state.topReactions}
-            customEmojiUrls={customEmojiUrls}
-            channelNames={channelNames}
-            dateRange={state.dateRange}
-            onDownload={analytics.trackReactionsShareCardDownloaded}
-            onCopy={analytics.trackReactionsShareCardCopied}
-          />
+          {/* Stats Cards */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-100 ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
+            <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} />
+          </div>
+
+          {/* Top Reactions + Top Creators (2/3 + 1/3 on desktop) */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-150 ${pageVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-3 scale-[0.98]"}`}>
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6">
+              <div className="lg:col-span-2">
+                <TopReactionsChart
+                  topReactions={state.topReactions}
+                  emojiFilter={state.emojiFilter}
+                  setEmojiFilter={(filter) => {
+                    analytics.trackReactionsFilterChanged(filter)
+                    state.setEmojiFilter(filter)
+                  }}
+                  customEmojiUrls={customEmojiUrls}
+                  emojiData={emojiData}
+                />
+              </div>
+              <div className="lg:col-span-1">
+                <TopCreators
+                  topReactions={state.topReactions}
+                  emojiData={emojiData}
+                  customEmojiUrls={customEmojiUrls}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* Timeline */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-200 ${pageVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-3 scale-[0.98]"}`}>
+            <ReactionTimeline data={state.timelineData} />
+          </div>
+
+          {/* Your Emojis + Share Card (1/2 + 1/2 on desktop) */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-300 ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
+              <YourReactions
+                userStats={state.userStats}
+                currentUserId={currentUserId}
+                customEmojiUrls={customEmojiUrls}
+              />
+              <ShareCardGenerator
+                stats={state.stats}
+                topReactions={state.topReactions}
+                customEmojiUrls={customEmojiUrls}
+                channelNames={channelNames}
+                dateRange={state.dateRange}
+                onDownload={analytics.trackReactionsShareCardDownloaded}
+                onCopy={analytics.trackReactionsShareCardCopied}
+              />
+            </div>
+          </div>
+
+          {/* Channel Breakdown */}
+          <div className={`px-3 sm:px-4 lg:px-6 transition-all duration-500 ease-out delay-300 ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
+            <ChannelBreakdown
+              breakdown={state.channelBreakdown}
+              channels={state.channels}
+              customEmojiUrls={customEmojiUrls}
+            />
+          </div>
         </>
       )}
     </div>

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -1,15 +1,13 @@
 "use client"
 
-import { useMemo, useEffect, useRef, useState } from "react"
-import { Activity, Hash, Settings, Info, Shield, Globe, HardDrive, Zap } from "lucide-react"
+import { useMemo, useEffect, useRef, useState, useCallback } from "react"
+import { Activity, Settings } from "lucide-react"
 import Link from "next/link"
 import { useEmojiData } from "@/lib/hooks/use-emoji-data"
 import { useIsClient } from "@/hooks/use-is-client"
 import { useAnalytics } from "@/lib/analytics"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
-import { Button } from "@/components/ui/button"
-import { InfoDrawerResponsive } from "@/components/info-drawer-responsive"
 import EmojiOverlay from "@/components/emoji-overlay"
 import type { Emoji } from "@/lib/services/emoji-service"
 import { useReactionsState } from "./hooks/use-reactions-state"
@@ -23,6 +21,7 @@ import { ChannelBreakdown } from "./components/channel-breakdown"
 import { ShareCardGenerator } from "./components/share-card-generator"
 import { TopCreators } from "./components/top-creators"
 import { TopReactors } from "./components/top-reactors"
+import { HowItWorksModal } from "./components/how-it-works-modal"
 
 export default function ReactionsPage() {
   const isClient = useIsClient()
@@ -37,34 +36,33 @@ export default function ReactionsPage() {
   const curlCommand = isClient ? localStorage.getItem("slackCurlCommand") : null
   const currentUserId = isClient ? localStorage.getItem("slackUserId") : null
 
-  // Single pass over emojiData to build both the name set and URL map
-  const { customEmojiNames, customEmojiUrls } = useMemo(() => {
+  // Single pass over emojiData to build all lookup maps
+  const { customEmojiNames, customEmojiUrls, emojiByName, userNameMap } = useMemo(() => {
     const names = new Set<string>()
     const urls = new Map<string, string>()
+    const byName = new Map<string, Emoji>()
+    const users = new Map<string, string>()
     for (const emoji of emojiData) {
-      if (!emoji.is_alias && emoji.url) {
-        names.add(emoji.name)
-        urls.set(emoji.name, emoji.url)
+      if (!emoji.is_alias) {
+        byName.set(emoji.name, emoji)
+        if (emoji.url) {
+          names.add(emoji.name)
+          urls.set(emoji.name, emoji.url)
+        }
+        if (emoji.user_id && emoji.user_display_name && !users.has(emoji.user_id)) {
+          users.set(emoji.user_id, emoji.user_display_name)
+        }
       }
     }
-    return { customEmojiNames: names, customEmojiUrls: urls }
-  }, [emojiData])
-
-  // Lookup map for opening emoji overlay by name
-  const emojiByName = useMemo(() => {
-    const map = new Map<string, Emoji>()
-    for (const emoji of emojiData) {
-      if (!emoji.is_alias) map.set(emoji.name, emoji)
-    }
-    return map
+    return { customEmojiNames: names, customEmojiUrls: urls, emojiByName: byName, userNameMap: users }
   }, [emojiData])
 
   const [selectedEmoji, setSelectedEmoji] = useState<Emoji | null>(null)
 
-  const handleEmojiClick = (name: string) => {
+  const handleEmojiClick = useCallback((name: string) => {
     const emoji = emojiByName.get(name)
     if (emoji) setSelectedEmoji(emoji)
-  }
+  }, [emojiByName])
 
   const analytics = useAnalytics()
   const state = useReactionsState(curlCommand, customEmojiNames)
@@ -125,79 +123,7 @@ export default function ReactionsPage() {
           <div>
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-bold tracking-tight">Usage</h1>
-              <InfoDrawerResponsive
-                trigger={
-                  <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground hover:text-foreground">
-                    <Info className="h-4 w-4" />
-                    <span className="sr-only">How this works</span>
-                  </Button>
-                }
-                title="How Usage Scanning Works"
-                description="Understand how Emoji Studio scans your Slack workspace and keeps your data secure."
-              >
-                <div className="space-y-6 text-sm">
-                  <div className="flex gap-3">
-                    <div className="rounded-lg bg-primary/10 p-2 h-fit shrink-0">
-                      <Zap className="h-4 w-4 text-primary" />
-                    </div>
-                    <div>
-                      <p className="font-medium">How it works</p>
-                      <p className="text-muted-foreground mt-1">
-                        Usage scanning reads message history from the Slack channels you select using the
-                        Slack <code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> API.
-                        It looks at emoji reactions on messages and aggregates them into charts
-                        and leaderboards &mdash; it does not read or store message content.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex gap-3">
-                    <div className="rounded-lg bg-green-500/10 p-2 h-fit shrink-0">
-                      <Shield className="h-4 w-4 text-green-500" />
-                    </div>
-                    <div>
-                      <p className="font-medium">Your credentials</p>
-                      <p className="text-muted-foreground mt-1">
-                        Authentication uses the same Slack session you set up in Settings.
-                        Your token is stored only in your browser&apos;s local storage and is never
-                        sent to any third-party server. API calls are proxied through a
-                        server-side route that <strong>only</strong> allows
-                        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.list</code> and
-                        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> &mdash;
-                        no other Slack endpoints are reachable.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex gap-3">
-                    <div className="rounded-lg bg-blue-500/10 p-2 h-fit shrink-0">
-                      <HardDrive className="h-4 w-4 text-blue-500" />
-                    </div>
-                    <div>
-                      <p className="font-medium">Data storage</p>
-                      <p className="text-muted-foreground mt-1">
-                        All reaction data is processed entirely in your browser. Scan results are
-                        cached locally so you don&apos;t have to re-scan every time. Nothing is uploaded
-                        to any external server or database &mdash; your data stays on your device.
-                      </p>
-                    </div>
-                  </div>
-
-                  <div className="flex gap-3">
-                    <div className="rounded-lg bg-orange-500/10 p-2 h-fit shrink-0">
-                      <Globe className="h-4 w-4 text-orange-500" />
-                    </div>
-                    <div>
-                      <p className="font-medium">Rate limiting</p>
-                      <p className="text-muted-foreground mt-1">
-                        Scans are rate-limited to avoid hitting Slack&apos;s API limits. Each channel
-                        is scanned sequentially with a delay between requests. Larger channels or
-                        longer date ranges will take more time.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </InfoDrawerResponsive>
+              <HowItWorksModal />
             </div>
             <p className="text-sm text-muted-foreground mt-1">
               See how your workspace&apos;s emojis are being used across Slack.
@@ -311,7 +237,7 @@ export default function ReactionsPage() {
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-6">
               <TopReactors
                 userStats={state.userStats}
-                emojiData={emojiData}
+                userNameMap={userNameMap}
                 customEmojiUrls={customEmojiUrls}
                 onEmojiClick={handleEmojiClick}
               />
@@ -355,7 +281,7 @@ export default function ReactionsPage() {
               breakdown={state.channelBreakdown}
               channels={state.channels}
               customEmojiUrls={customEmojiUrls}
-              emojiData={emojiData}
+              userNameMap={userNameMap}
               onEmojiClick={handleEmojiClick}
             />
           </div>

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -16,35 +16,27 @@ import { ChannelBreakdown } from "./components/channel-breakdown"
 import { ShareCardGenerator } from "./components/share-card-generator"
 import { TopCreators } from "./components/top-creators"
 
-function ReactionsPage() {
+export default function ReactionsPage() {
   const isClient = useIsClient()
   const { emojiData, hasRealData } = useEmojiData()
 
-  const curlCommand =
-    isClient ? (typeof window !== "undefined" ? localStorage.getItem("slackCurlCommand") : null) : null
+  const curlCommand = isClient ? localStorage.getItem("slackCurlCommand") : null
+  const currentUserId = isClient ? localStorage.getItem("slackUserId") : null
 
-  const currentUserId =
-    isClient ? (typeof window !== "undefined" ? localStorage.getItem("slackUserId") : null) : null
-
-  const customEmojiNames = useMemo(() => {
+  // Single pass over emojiData to build both the name set and URL map
+  const { customEmojiNames, customEmojiUrls } = useMemo(() => {
     const names = new Set<string>()
+    const urls = new Map<string, string>()
     for (const emoji of emojiData) {
-      if (emoji.url && !emoji.is_alias) names.add(emoji.name)
+      if (!emoji.is_alias && emoji.url) {
+        names.add(emoji.name)
+        urls.set(emoji.name, emoji.url)
+      }
     }
-    return names
+    return { customEmojiNames: names, customEmojiUrls: urls }
   }, [emojiData])
 
   const state = useReactionsState(curlCommand, customEmojiNames)
-
-  const customEmojiUrls = useMemo(() => {
-    const map = new Map<string, string>()
-    for (const emoji of emojiData) {
-      if (!emoji.is_alias) {
-        map.set(emoji.name, emoji.url)
-      }
-    }
-    return map
-  }, [emojiData])
 
   const hasData = state.reactionEvents.length > 0
 
@@ -65,7 +57,6 @@ function ReactionsPage() {
 
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
-      {/* Header */}
       <div>
         <h1 className="text-2xl font-bold tracking-tight">Reactions Dashboard</h1>
         <p className="text-sm text-muted-foreground mt-1">
@@ -73,7 +64,6 @@ function ReactionsPage() {
         </p>
       </div>
 
-      {/* Channel picker + scan controls */}
       <ChannelPicker
         channels={state.channels}
         selectedChannels={state.selectedChannels}
@@ -86,7 +76,6 @@ function ReactionsPage() {
         scanStatus={state.scanProgress.status}
       />
 
-      {/* Scan progress indicator */}
       <ScanProgress
         status={state.scanProgress.status}
         currentChannel={state.scanProgress.current_channel}
@@ -96,7 +85,6 @@ function ReactionsPage() {
         onCancel={state.cancelScan}
       />
 
-      {/* Empty state */}
       {!hasData && (
         <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
           <BarChart3 className="h-12 w-12 opacity-30" />
@@ -108,7 +96,6 @@ function ReactionsPage() {
         </div>
       )}
 
-      {/* Results */}
       {hasData && (
         <>
           <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} />
@@ -148,8 +135,4 @@ function ReactionsPage() {
       )}
     </div>
   )
-}
-
-export default function ReactionsPageWrapper() {
-  return <ReactionsPage />
 }

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -1,0 +1,130 @@
+"use client"
+
+import { useMemo } from "react"
+import { BarChart3 } from "lucide-react"
+import { useEmojiData } from "@/lib/hooks/use-emoji-data"
+import { useIsClient } from "@/hooks/use-is-client"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useReactionsState } from "./hooks/use-reactions-state"
+import { ChannelPicker } from "./components/channel-picker"
+import { ScanProgress } from "./components/scan-progress"
+import { ReactionStatsCards } from "./components/reaction-stats-cards"
+import { TopReactionsChart } from "./components/top-reactions-chart"
+import { ReactionTimeline } from "./components/reaction-timeline"
+import { YourReactions } from "./components/your-reactions"
+import { ChannelBreakdown } from "./components/channel-breakdown"
+
+function ReactionsPage() {
+  const isClient = useIsClient()
+  const { emojiData, hasRealData } = useEmojiData()
+
+  const curlCommand =
+    isClient ? (typeof window !== "undefined" ? localStorage.getItem("slackCurlCommand") : null) : null
+
+  const currentUserId =
+    isClient ? (typeof window !== "undefined" ? localStorage.getItem("slackUserId") : null) : null
+
+  const state = useReactionsState(curlCommand)
+
+  const customEmojiUrls = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const emoji of emojiData) {
+      if (!emoji.is_alias) {
+        map.set(emoji.name, emoji.url)
+      }
+    }
+    return map
+  }, [emojiData])
+
+  const hasData = state.reactionEvents.length > 0
+
+  if (!isClient) {
+    return (
+      <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-16 w-full" />
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6 pb-8 w-full">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Reactions Dashboard</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Scan Slack channels to explore emoji reaction activity.
+        </p>
+      </div>
+
+      {/* Channel picker + scan controls */}
+      <ChannelPicker
+        channels={state.channels}
+        selectedChannels={state.selectedChannels}
+        setSelectedChannels={state.setSelectedChannels}
+        channelsLoading={state.channelsLoading}
+        fetchChannels={state.fetchChannels}
+        dateRange={state.dateRange}
+        setDateRange={state.setDateRange}
+        onScan={state.startScan}
+        scanStatus={state.scanProgress.status}
+      />
+
+      {/* Scan progress indicator */}
+      <ScanProgress
+        status={state.scanProgress.status}
+        currentChannel={state.scanProgress.current_channel}
+        channelsDone={state.scanProgress.channels_done}
+        channelsTotal={state.scanProgress.channels_total}
+        reactionsFound={state.scanProgress.reactions_found}
+        onCancel={state.cancelScan}
+      />
+
+      {/* Empty state */}
+      {!hasData && (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
+          <BarChart3 className="h-12 w-12 opacity-30" />
+          <p className="text-sm">
+            {!hasRealData
+              ? "Connect to Slack in Settings to get started."
+              : "Select channels above and run a scan to see reaction data."}
+          </p>
+        </div>
+      )}
+
+      {/* Results */}
+      {hasData && (
+        <>
+          <ReactionStatsCards stats={state.stats} customEmojiUrls={customEmojiUrls} />
+          <TopReactionsChart
+            topReactions={state.topReactions}
+            emojiFilter={state.emojiFilter}
+            setEmojiFilter={state.setEmojiFilter}
+            customEmojiUrls={customEmojiUrls}
+          />
+          <ReactionTimeline data={state.timelineData} />
+          <YourReactions
+            userStats={state.userStats}
+            currentUserId={currentUserId}
+            customEmojiUrls={customEmojiUrls}
+          />
+          <ChannelBreakdown
+            breakdown={state.channelBreakdown}
+            channels={state.channels}
+            customEmojiUrls={customEmojiUrls}
+          />
+        </>
+      )}
+    </div>
+  )
+}
+
+export default function ReactionsPageWrapper() {
+  return <ReactionsPage />
+}

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -1,13 +1,15 @@
 "use client"
 
 import { useMemo, useEffect, useRef, useState } from "react"
-import { Activity, Hash, Settings } from "lucide-react"
+import { Activity, Hash, Settings, Info, Shield, Globe, HardDrive, Zap } from "lucide-react"
 import Link from "next/link"
 import { useEmojiData } from "@/lib/hooks/use-emoji-data"
 import { useIsClient } from "@/hooks/use-is-client"
 import { useAnalytics } from "@/lib/analytics"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { InfoDrawerResponsive } from "@/components/info-drawer-responsive"
 import { useReactionsState } from "./hooks/use-reactions-state"
 import { ChannelPicker } from "./components/channel-picker"
 import { ScanProgress } from "./components/scan-progress"
@@ -102,7 +104,82 @@ export default function ReactionsPage() {
       <div className={`px-3 sm:px-4 lg:px-6 pt-4 md:pt-6 transition-all duration-500 ease-out ${pageVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-3"}`}>
         <div className="flex flex-col gap-4">
           <div>
-            <h1 className="text-2xl font-bold tracking-tight">Usage</h1>
+            <div className="flex items-center gap-2">
+              <h1 className="text-2xl font-bold tracking-tight">Usage</h1>
+              <InfoDrawerResponsive
+                trigger={
+                  <Button variant="ghost" size="icon" className="h-7 w-7 text-muted-foreground hover:text-foreground">
+                    <Info className="h-4 w-4" />
+                    <span className="sr-only">How this works</span>
+                  </Button>
+                }
+                title="How Usage Scanning Works"
+                description="Understand how Emoji Studio scans your Slack workspace and keeps your data secure."
+              >
+                <div className="space-y-6 text-sm">
+                  <div className="flex gap-3">
+                    <div className="rounded-lg bg-primary/10 p-2 h-fit shrink-0">
+                      <Zap className="h-4 w-4 text-primary" />
+                    </div>
+                    <div>
+                      <p className="font-medium">How it works</p>
+                      <p className="text-muted-foreground mt-1">
+                        Usage scanning reads message history from the Slack channels you select using the
+                        Slack <code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> API.
+                        It looks at emoji reactions on messages and aggregates them into charts
+                        and leaderboards &mdash; it does not read or store message content.
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex gap-3">
+                    <div className="rounded-lg bg-green-500/10 p-2 h-fit shrink-0">
+                      <Shield className="h-4 w-4 text-green-500" />
+                    </div>
+                    <div>
+                      <p className="font-medium">Your credentials</p>
+                      <p className="text-muted-foreground mt-1">
+                        Authentication uses the same Slack session you set up in Settings.
+                        Your token is stored only in your browser&apos;s local storage and is never
+                        sent to any third-party server. API calls are proxied through a
+                        server-side route that <strong>only</strong> allows
+                        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.list</code> and
+                        {" "}<code className="text-xs bg-muted px-1 py-0.5 rounded">conversations.history</code> &mdash;
+                        no other Slack endpoints are reachable.
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex gap-3">
+                    <div className="rounded-lg bg-blue-500/10 p-2 h-fit shrink-0">
+                      <HardDrive className="h-4 w-4 text-blue-500" />
+                    </div>
+                    <div>
+                      <p className="font-medium">Data storage</p>
+                      <p className="text-muted-foreground mt-1">
+                        All reaction data is processed entirely in your browser. Scan results are
+                        cached locally so you don&apos;t have to re-scan every time. Nothing is uploaded
+                        to any external server or database &mdash; your data stays on your device.
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="flex gap-3">
+                    <div className="rounded-lg bg-orange-500/10 p-2 h-fit shrink-0">
+                      <Globe className="h-4 w-4 text-orange-500" />
+                    </div>
+                    <div>
+                      <p className="font-medium">Rate limiting</p>
+                      <p className="text-muted-foreground mt-1">
+                        Scans are rate-limited to avoid hitting Slack&apos;s API limits. Each channel
+                        is scanned sequentially with a delay between requests. Larger channels or
+                        longer date ranges will take more time.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </InfoDrawerResponsive>
+            </div>
             <p className="text-sm text-muted-foreground mt-1">
               See how your workspace&apos;s emojis are being used across Slack.
             </p>

--- a/app/reactions/page.tsx
+++ b/app/reactions/page.tsx
@@ -13,6 +13,7 @@ import { TopReactionsChart } from "./components/top-reactions-chart"
 import { ReactionTimeline } from "./components/reaction-timeline"
 import { YourReactions } from "./components/your-reactions"
 import { ChannelBreakdown } from "./components/channel-breakdown"
+import { ShareCardGenerator } from "./components/share-card-generator"
 
 function ReactionsPage() {
   const isClient = useIsClient()
@@ -118,6 +119,15 @@ function ReactionsPage() {
             breakdown={state.channelBreakdown}
             channels={state.channels}
             customEmojiUrls={customEmojiUrls}
+          />
+          <ShareCardGenerator
+            stats={state.stats}
+            topReactions={state.topReactions}
+            customEmojiUrls={customEmojiUrls}
+            channelNames={state.selectedChannels.map(
+              id => state.channels.find(c => c.id === id)?.name ?? id
+            )}
+            dateRange={state.dateRange}
           />
         </>
       )}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -603,6 +603,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       icon: LayoutDashboardIcon,
     },
     {
+      title: "Usage",
+      url: "/reactions",
+      icon: Activity,
+      badge: "NEW",
+    },
+    {
       title: "Leaderboard",
       url: "/leaderboard",
       icon: TrophyIcon,
@@ -626,12 +632,6 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       title: "Wrapped",
       url: "/wrapped",
       icon: Gift,
-    },
-    {
-      title: "Usage",
-      url: "/reactions",
-      icon: Activity,
-      badge: "NEW",
     },
     {
       title: "Settings",

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
 import {
+  BarChart3,
   BarChartIcon,
   LayoutDashboardIcon,
   SettingsIcon,
@@ -625,6 +626,11 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       title: "Wrapped",
       url: "/wrapped",
       icon: Gift,
+    },
+    {
+      title: "Reactions",
+      url: "/reactions",
+      icon: BarChart3,
     },
     {
       title: "Settings",

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation"
 import Link from "next/link"
 import Image from "next/image"
 import {
-  BarChart3,
+  Activity,
   BarChartIcon,
   LayoutDashboardIcon,
   SettingsIcon,
@@ -628,9 +628,9 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       icon: Gift,
     },
     {
-      title: "Reactions",
+      title: "Usage",
       url: "/reactions",
-      icon: BarChart3,
+      icon: Activity,
     },
     {
       title: "Settings",

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -631,6 +631,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       title: "Usage",
       url: "/reactions",
       icon: Activity,
+      badge: "NEW",
     },
     {
       title: "Settings",

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -7,7 +7,6 @@ import { usePathname, useRouter } from "next/navigation"
 import { cn } from "@/lib/utils"
 import { XCircle } from "lucide-react"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { TextShimmer } from "@/components/ui/text-shimmer"
 
 interface NavMainProps {
   items: {
@@ -39,8 +38,7 @@ export function NavMain({ items, onRefresh, refreshing, slackLoaded, onNavigate,
         const isRefresh = item.action === "refresh"
         const isFeedback = item.action === "feedback"
         const isSettings = item.url === "/settings"
-        const isWrapped = item.url === "/wrapped"
-        const isDisabled = (isRefresh && refreshing) || (!hasData && !isSettings && !isWrapped && !item.external && !isFeedback)
+        const isDisabled = (isRefresh && refreshing) || (!hasData && !isSettings && item.url !== "/wrapped" && !item.external && !isFeedback)
 
         // Handle refresh action
         const handleClick = (e: React.MouseEvent) => {
@@ -123,26 +121,6 @@ export function NavMain({ items, onRefresh, refreshing, slackLoaded, onNavigate,
           </>
         )
 
-        // Special content for Wrapped link with shimmer effect
-        const wrappedLinkContent = (
-          <>
-            <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
-            <TextShimmer
-              as="span"
-              className="text-sm font-medium [--base-color:#f97316] [--base-gradient-color:#fbbf24] dark:[--base-color:#f97316] dark:[--base-gradient-color:#fef3c7]"
-              duration={1.5}
-              spread={1.5}
-            >
-              {item.title}
-            </TextShimmer>
-            {item.badge && (
-              <span className="ml-1.5 inline-flex items-center rounded-full bg-green-700 px-2 py-0.5 text-xs font-medium text-white uppercase">
-                {item.badge}
-              </span>
-            )}
-          </>
-        )
-
         const link = (
           <Link
             key={item.title}
@@ -159,7 +137,7 @@ export function NavMain({ items, onRefresh, refreshing, slackLoaded, onNavigate,
             {isActive && (
               <span className="absolute left-0 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-r-full bg-[hsl(var(--brand))]" />
             )}
-            {isWrapped && !isActive ? wrappedLinkContent : linkContent}
+            {linkContent}
           </Link>
         )
 

--- a/components/section-cards.tsx
+++ b/components/section-cards.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from "react";
 import { TrendingDownIcon, TrendingUpIcon } from "lucide-react";
 
-import { cn } from "@/lib/utils";
+import { cn, trendBadgeColors } from "@/lib/utils";
 import { useEmojiData } from "@/lib/hooks/use-emoji-data";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
@@ -15,13 +15,6 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart";
 import { CartesianGrid, Line, LineChart, XAxis, LabelList } from "recharts";
-
-/** Returns badge color classes based on positive/negative trend */
-function trendBadgeColors(isPositive: boolean) {
-  return isPositive
-    ? "text-green-600 bg-green-500/10 dark:text-green-400 dark:bg-green-500/20"
-    : "text-red-600 bg-red-500/10 dark:text-red-400 dark:bg-red-500/20";
-}
 
 export function SectionCards() {
   const { stats, loading, emojiData, userLeaderboard, useDemoData, hasRealData } = useEmojiData();

--- a/components/ui/progress.tsx
+++ b/components/ui/progress.tsx
@@ -18,7 +18,7 @@ const Progress = React.forwardRef<
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-[var(--progress-color,hsl(var(--primary)))] transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -20,6 +20,12 @@ export enum AnalyticsEvent {
   FEEDBACK_MODAL_CLOSED = 'Feedback Modal Closed',
   FEEDBACK_SUBMITTED = 'Feedback Submitted',
   FEEDBACK_SUBMISSION_FAILED = 'Feedback Submission Failed',
+  REACTIONS_SCAN_STARTED = 'Reactions Scan Started',
+  REACTIONS_SCAN_COMPLETED = 'Reactions Scan Completed',
+  REACTIONS_FILTER_CHANGED = 'Reactions Filter Changed',
+  REACTIONS_DATE_RANGE_CHANGED = 'Reactions Date Range Changed',
+  REACTIONS_SHARE_CARD_DOWNLOADED = 'Reactions Share Card Downloaded',
+  REACTIONS_SHARE_CARD_COPIED = 'Reactions Share Card Copied',
 }
 
 // Analytics utility hook to track events in the emoji dashboard
@@ -173,6 +179,45 @@ export function useAnalytics() {
         error_message: error,
         workspace,
       });
+    },
+
+    trackReactionsScanStarted: (channelCount: number, dateRange: string) => {
+      op.track(AnalyticsEvent.REACTIONS_SCAN_STARTED, {
+        channel_count: channelCount,
+        date_range: dateRange,
+        workspace,
+      });
+    },
+
+    trackReactionsScanCompleted: (channelCount: number, reactionsFound: number, dateRange: string) => {
+      op.track(AnalyticsEvent.REACTIONS_SCAN_COMPLETED, {
+        channel_count: channelCount,
+        reactions_found: reactionsFound,
+        date_range: dateRange,
+        workspace,
+      });
+    },
+
+    trackReactionsFilterChanged: (filter: string) => {
+      op.track(AnalyticsEvent.REACTIONS_FILTER_CHANGED, {
+        filter,
+        workspace,
+      });
+    },
+
+    trackReactionsDateRangeChanged: (dateRange: string) => {
+      op.track(AnalyticsEvent.REACTIONS_DATE_RANGE_CHANGED, {
+        date_range: dateRange,
+        workspace,
+      });
+    },
+
+    trackReactionsShareCardDownloaded: () => {
+      op.track(AnalyticsEvent.REACTIONS_SHARE_CARD_DOWNLOADED, { workspace });
+    },
+
+    trackReactionsShareCardCopied: () => {
+      op.track(AnalyticsEvent.REACTIONS_SHARE_CARD_COPIED, { workspace });
     },
 
     // Identify a user - also caches to localStorage for session restore

--- a/lib/services/reaction-service.ts
+++ b/lib/services/reaction-service.ts
@@ -1,0 +1,256 @@
+/**
+ * Reaction Service
+ *
+ * Core types and pure aggregation functions for the Reactions Dashboard.
+ * No React, no I/O — pure data transformations only (plus storage helpers).
+ */
+
+import { idb } from '@/lib/storage/indexed-db'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReactionEvent {
+  emoji_name: string
+  count: number
+  user_ids: string[]
+  channel_id: string
+  timestamp: number // Unix epoch seconds
+}
+
+export interface AggregatedReaction {
+  emoji_name: string
+  total_count: number
+  unique_users: number
+  events: ReactionEvent[]
+}
+
+export interface TrendingReaction {
+  emoji_name: string
+  recent_count: number
+  previous_count: number
+  change_percent: number
+}
+
+export interface UserReactionStat {
+  user_id: string
+  reaction_count: number
+  top_emojis: string[]
+}
+
+export interface ChannelReactionBreakdown {
+  channel_id: string
+  total_count: number
+  top_reactions: AggregatedReaction[]
+}
+
+export interface ReactionScanMeta {
+  scanned_at: number // Unix epoch ms
+  channel_ids: string[]
+  event_count: number
+}
+
+export interface ReactionStats {
+  total_reactions: number
+  unique_emojis: number
+  unique_users: number
+  top_reactions: AggregatedReaction[]
+  trending: TrendingReaction[]
+}
+
+// ---------------------------------------------------------------------------
+// Pure aggregation functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Combine reaction events into per-emoji aggregates.
+ */
+export function aggregateReactions(events: ReactionEvent[]): AggregatedReaction[] {
+  const map = new Map<string, { total_count: number; user_ids: Set<string>; events: ReactionEvent[] }>()
+
+  for (const event of events) {
+    let entry = map.get(event.emoji_name)
+    if (!entry) {
+      entry = { total_count: 0, user_ids: new Set(), events: [] }
+      map.set(event.emoji_name, entry)
+    }
+    entry.total_count += event.count
+    for (const uid of event.user_ids) {
+      entry.user_ids.add(uid)
+    }
+    entry.events.push(event)
+  }
+
+  return Array.from(map.entries()).map(([emoji_name, entry]) => ({
+    emoji_name,
+    total_count: entry.total_count,
+    unique_users: entry.user_ids.size,
+    events: entry.events,
+  }))
+}
+
+/**
+ * Return the top N reactions sorted by total_count descending.
+ */
+export function getTopReactions(aggregated: AggregatedReaction[], limit: number): AggregatedReaction[] {
+  return [...aggregated].sort((a, b) => b.total_count - a.total_count).slice(0, limit)
+}
+
+/**
+ * Identify emojis whose usage increased in the recent window vs. the prior
+ * window of the same length.
+ *
+ * @param events   All reaction events.
+ * @param windowSeconds  Length of the "recent" period in seconds (e.g. 7 * 86400).
+ */
+export function getTrendingReactions(events: ReactionEvent[], windowSeconds: number): TrendingReaction[] {
+  const now = Math.floor(Date.now() / 1000)
+  const recentStart = now - windowSeconds
+  const previousStart = recentStart - windowSeconds
+
+  // Bucket counts per emoji
+  const recent = new Map<string, number>()
+  const previous = new Map<string, number>()
+
+  for (const event of events) {
+    if (event.timestamp >= recentStart) {
+      recent.set(event.emoji_name, (recent.get(event.emoji_name) ?? 0) + event.count)
+    } else if (event.timestamp >= previousStart) {
+      previous.set(event.emoji_name, (previous.get(event.emoji_name) ?? 0) + event.count)
+    }
+  }
+
+  const trending: TrendingReaction[] = []
+
+  for (const [emoji_name, recent_count] of recent.entries()) {
+    const previous_count = previous.get(emoji_name) ?? 0
+
+    let change_percent: number
+    if (previous_count === 0) {
+      change_percent = recent_count > 0 ? 100 : 0
+    } else {
+      change_percent = Math.round(((recent_count - previous_count) / previous_count) * 100)
+    }
+
+    if (change_percent > 0) {
+      trending.push({ emoji_name, recent_count, previous_count, change_percent })
+    }
+  }
+
+  return trending.sort((a, b) => b.change_percent - a.change_percent)
+}
+
+/**
+ * Aggregate how many distinct events each user appeared in.
+ * reaction_count = number of events that include this user's ID.
+ */
+export function getUserReactionStats(events: ReactionEvent[]): UserReactionStat[] {
+  // Track: per user → set of event indices (to count distinct events)
+  const userEvents = new Map<string, { eventCount: number; emojis: Map<string, number> }>()
+
+  for (const event of events) {
+    for (const uid of event.user_ids) {
+      let entry = userEvents.get(uid)
+      if (!entry) {
+        entry = { eventCount: 0, emojis: new Map() }
+        userEvents.set(uid, entry)
+      }
+      entry.eventCount += 1
+      entry.emojis.set(event.emoji_name, (entry.emojis.get(event.emoji_name) ?? 0) + event.count)
+    }
+  }
+
+  return Array.from(userEvents.entries()).map(([user_id, entry]) => {
+    const top_emojis = [...entry.emojis.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name]) => name)
+
+    return {
+      user_id,
+      reaction_count: entry.eventCount,
+      top_emojis,
+    }
+  })
+}
+
+/**
+ * Group and aggregate reactions by channel, returning the top N reactions
+ * per channel sorted by total count.
+ */
+export function getChannelBreakdown(events: ReactionEvent[], topN: number): ChannelReactionBreakdown[] {
+  const channelEvents = new Map<string, ReactionEvent[]>()
+
+  for (const event of events) {
+    let list = channelEvents.get(event.channel_id)
+    if (!list) {
+      list = []
+      channelEvents.set(event.channel_id, list)
+    }
+    list.push(event)
+  }
+
+  return Array.from(channelEvents.entries()).map(([channel_id, evts]) => {
+    const aggregated = aggregateReactions(evts)
+    const sorted = getTopReactions(aggregated, topN)
+    const total_count = aggregated.reduce((sum, r) => sum + r.total_count, 0)
+    return { channel_id, total_count, top_reactions: sorted }
+  })
+}
+
+/**
+ * Compute a high-level stats summary from an array of reaction events.
+ */
+export function calculateReactionStats(events: ReactionEvent[]): ReactionStats {
+  const aggregated = aggregateReactions(events)
+
+  const allUsers = new Set<string>()
+  for (const event of events) {
+    for (const uid of event.user_ids) allUsers.add(uid)
+  }
+
+  return {
+    total_reactions: events.reduce((sum, e) => sum + e.count, 0),
+    unique_emojis: aggregated.length,
+    unique_users: allUsers.size,
+    top_reactions: getTopReactions(aggregated, 10),
+    trending: getTrendingReactions(events, 7 * 86400),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Storage helpers (IndexedDB via existing singleton)
+// ---------------------------------------------------------------------------
+
+const CACHE_KEY = 'reaction_events'
+const TTL_MS = 24 * 60 * 60 * 1000 // 24 hours
+
+export const reactionStorage = {
+  async saveReactions(events: ReactionEvent[], meta?: ReactionScanMeta): Promise<void> {
+    await idb.setItem('cache', CACHE_KEY, { events, meta: meta ?? null })
+  },
+
+  async loadReactions(): Promise<{ events: ReactionEvent[]; meta: ReactionScanMeta | null } | null> {
+    // idb.getItem for the 'cache' store returns the value portion only;
+    // the timestamp is stored separately in the IndexedDB record.
+    // We re-read the raw record by relying on the fact that the cache store
+    // attaches a `timestamp` field — but getItem strips it.  To check TTL
+    // we store our own scanned_at in the meta object instead.
+    const data = await idb.getItem('cache', CACHE_KEY)
+    if (!data) return null
+
+    // Check freshness via meta.scanned_at when available
+    const scannedAt: number = data.meta?.scanned_at ?? 0
+    if (scannedAt && Date.now() - scannedAt > TTL_MS) {
+      await idb.removeItem('cache', CACHE_KEY)
+      return null
+    }
+
+    return data as { events: ReactionEvent[]; meta: ReactionScanMeta | null }
+  },
+
+  async clearReactions(): Promise<void> {
+    await idb.removeItem('cache', CACHE_KEY)
+  },
+}

--- a/lib/services/reaction-service.ts
+++ b/lib/services/reaction-service.ts
@@ -32,10 +32,16 @@ export interface UserReactionStat {
   top_emojis: string[]
 }
 
+export interface ChannelReactorStat {
+  user_id: string
+  reaction_count: number
+}
+
 export interface ChannelReactionBreakdown {
   channel_id: string
   total_count: number
   top_reactions: AggregatedReaction[]
+  top_reactors: ChannelReactorStat[]
 }
 
 export interface ReactionScanMeta {
@@ -188,7 +194,20 @@ export function getChannelBreakdown(events: ReactionEvent[], topN: number): Chan
     const aggregated = aggregateReactions(evts)
     const sorted = getTopReactions(aggregated, topN)
     const total_count = aggregated.reduce((sum, r) => sum + r.total_count, 0)
-    return { channel_id, total_count, top_reactions: sorted }
+
+    // Compute top reactors for this channel
+    const userCounts = new Map<string, number>()
+    for (const evt of evts) {
+      for (const uid of evt.user_ids) {
+        userCounts.set(uid, (userCounts.get(uid) ?? 0) + 1)
+      }
+    }
+    const top_reactors = Array.from(userCounts.entries())
+      .map(([user_id, reaction_count]) => ({ user_id, reaction_count }))
+      .sort((a, b) => b.reaction_count - a.reaction_count)
+      .slice(0, 5)
+
+    return { channel_id, total_count, top_reactions: sorted, top_reactors }
   })
 }
 

--- a/lib/services/reaction-service.ts
+++ b/lib/services/reaction-service.ts
@@ -1,10 +1,3 @@
-/**
- * Reaction Service
- *
- * Core types and pure aggregation functions for the Reactions Dashboard.
- * No React, no I/O — pure data transformations only (plus storage helpers).
- */
-
 import { idb } from '@/lib/storage/indexed-db'
 
 // ---------------------------------------------------------------------------

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -55,3 +55,10 @@ export function formatEmojiName(name: string): string {
 export function formatSlackEmojiDisplay(name: string): string {
   return `:${formatEmojiName(name)}:`
 }
+
+/** Returns badge color classes for positive/negative trend indicators */
+export function trendBadgeColors(isPositive: boolean) {
+  return isPositive
+    ? "text-green-600 bg-green-500/10 dark:text-green-400 dark:bg-green-500/20"
+    : "text-red-600 bg-red-500/10 dark:text-red-400 dark:bg-red-500/20"
+}


### PR DESCRIPTION
## Summary

Renames the Reactions page to **Usage** and gives it a comprehensive UI polish pass to match the quality of the main dashboard.

### Rename
- Sidebar nav: "Reactions" → "Usage" with `Activity` icon + **NEW** badge
- Page title, subtitle, button text, and card titles updated
- URL path `/reactions` unchanged (no breaking links)

### UI Polish
- **Responsive padding** — per-section `px-3 sm:px-4 lg:px-6` matching the dashboard pattern
- **Two-column grid** — TopReactionsChart + TopCreators (2/3 + 1/3), YourEmojis + ShareCard (1/2 + 1/2) on `lg+`
- **Staggered fade-in animations** — sections animate in with 100–300ms delays on page load
- **Header cohesion** — title and channel picker grouped tightly
- **Improved empty state** — card with numbered steps or Settings link depending on connection status
- **Updated skeleton** — matches the new two-column layout shape

### Chart Upgrades
- **TopCreators** — replaced manual HTML bars with a proper recharts horizontal `BarChart` in a shadcn `ChartContainer` with tooltips
- **ReactionTimeline** — enhanced with split header showing total + peak stats, `CardDescription`, and `natural` curve interpolation

### Info Modal
- "How this works" button next to page title opens a responsive modal (dialog on desktop, drawer on mobile)
- Explains scanning mechanics, credential security, local-only data storage, and rate limiting

## Test plan
- [ ] Sidebar shows "Usage" with Activity icon and NEW badge
- [ ] Page renders with responsive padding and two-column grid on desktop
- [ ] Fade-in animations play on page load
- [ ] Empty state shows correctly for both unconnected and connected states
- [ ] Info modal opens/closes on desktop and mobile
- [ ] TopCreators horizontal bar chart renders with tooltips
- [ ] ReactionTimeline shows total + peak in the header
- [ ] Scan flow works end-to-end (select channels → scan → results)
- [ ] `next build` passes with no errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)